### PR TITLE
Support filtering by kwargs as a first-class operation.

### DIFF
--- a/microcosm_postgres/store.py
+++ b/microcosm_postgres/store.py
@@ -122,12 +122,14 @@ class Store(object):
         """
         return self._delete(self.model_class.id == identifier)
 
-    def count(self, *criterion):
+    def count(self, *criterion, **kwargs):
         """
         Count the number of models matching some criterion.
 
         """
-        return self._query(*criterion).count()
+        query = self._query(*criterion)
+        query = self._filter(query, **kwargs)
+        return query.count()
 
     def search(self, *criterion, **kwargs):
         """
@@ -135,14 +137,26 @@ class Store(object):
 
         :param offset: pagination offset, if any
         :param limit: pagination limit, if any
+
         """
         query = self._query(*criterion)
+        query = self._filter(query, **kwargs)
+        return query.all()
+
+    def _filter(self, query, **kwargs):
+        """
+        Filter a query with user-supplied arguments.
+
+        :param offset: pagination offset, if any
+        :param limit: pagination limit, if any
+
+        """
         offset, limit = kwargs.get("offset"), kwargs.get("limit")
         if offset is not None:
             query = query.offset(offset)
         if limit is not None:
             query = query.limit(limit)
-        return query.all()
+        return query
 
     def _retrieve(self, *criterion):
         """

--- a/microcosm_postgres/tests/example.py
+++ b/microcosm_postgres/tests/example.py
@@ -41,6 +41,13 @@ class EmployeeStore(Store):
     def search_by_company(self, company_id):
         return self.search(Employee.company_id == company_id)
 
+    def _filter(self, query, **kwargs):
+        query = super(EmployeeStore, self)._filter(query, **kwargs)
+        company_id = kwargs.get("company_id")
+        if company_id is not None:
+            query = query.filter(Employee.company_id == company_id)
+        return query
+
 
 @binding("company_store")
 def configure_company_store(graph):


### PR DESCRIPTION
Allow searching and counting to use kwargs to filter queries.

This makes it easier to bind searches directly to generic query string arguments for various kinds of filtering.