### PR TITLE
Support update_with_diff

### DIFF
--- a/microcosm_postgres/diff.py
+++ b/microcosm_postgres/diff.py
@@ -2,9 +2,13 @@
 Compute ORM differences.
 
 """
+from collections import namedtuple
 from itertools import chain
 
 from sqlalchemy.orm import class_mapper, ColumnProperty
+
+
+Change = namedtuple("Change", ["before", "after"])
 
 
 class Version(dict):
@@ -33,7 +37,7 @@ class Delta(dict):
     """
     def __init__(self, left, right):
         super(Delta, self).__init__({
-            key: right.get(key)
+            key: Change(left.get(key), right.get(key))
             for key in set(chain(left.keys(), right.keys()))
             if left.get(key) != right.get(key)
         })

--- a/microcosm_postgres/diff.py
+++ b/microcosm_postgres/diff.py
@@ -1,0 +1,39 @@
+"""
+Compute ORM differences.
+
+"""
+from itertools import chain
+
+from sqlalchemy.orm import class_mapper, ColumnProperty
+
+
+class Version(dict):
+    """
+    Capture of object state a specific time.
+
+    """
+    def __init__(self, instance):
+        super(Version, self).__init__({
+            prop.key: getattr(instance, prop.key)
+            for prop in class_mapper(instance.__class__).iterate_properties
+            if isinstance(prop, ColumnProperty)
+        })
+
+    def difference(self, other):
+        return Delta(self, other)
+
+    def __sub__(self, other):
+        return Delta(self, other)
+
+
+class Delta(dict):
+    """
+    Difference beween two object versions.
+
+    """
+    def __init__(self, left, right):
+        super(Delta, self).__init__({
+            key: right.get(key)
+            for key in set(chain(left.keys(), right.keys()))
+            if left.get(key) != right.get(key)
+        })

--- a/microcosm_postgres/models.py
+++ b/microcosm_postgres/models.py
@@ -89,6 +89,9 @@ class SmartMixin(object):
     def update(self):
         return self.__class__.store.update(self.id, self)
 
+    def update_with_diff(self):
+        return self.__class__.store.update_with_diff(self.id, self)
+
     def replace(self):
         return self.__class__.store.replace(self.id, self)
 

--- a/microcosm_postgres/tests/test_example.py
+++ b/microcosm_postgres/tests/test_example.py
@@ -7,8 +7,6 @@ from hamcrest import (
     calling,
     contains_inanyorder,
     equal_to,
-    has_entry,
-    has_key,
     is_,
     raises,
 )
@@ -117,8 +115,9 @@ class TestCompany(object):
                 id=company.id,
                 name="new_name",
             ).update_with_diff()
-            assert_that(diff, has_key("updated_at"))
-            assert_that(diff, has_entry("name", "new_name"))
+            assert_that(diff.keys(), contains_inanyorder("name", "updated_at"))
+            assert_that(diff["name"].before, is_(equal_to("name")))
+            assert_that(diff["name"].after, is_(equal_to("new_name")))
 
         with transaction():
             retrieved_company = Company.retrieve(company.id)
@@ -242,8 +241,9 @@ class TestEmployee(object):
                 id=employee.id,
                 last="Doe",
             ).update_with_diff()
-            assert_that(diff, has_key("updated_at"))
-            assert_that(diff, has_entry("last", "Doe"))
+            assert_that(diff.keys(), contains_inanyorder("last", "updated_at"))
+            assert_that(diff["last"].before, is_(equal_to("last")))
+            assert_that(diff["last"].after, is_(equal_to("Doe")))
 
         with transaction():
             retrieved_employee = Employee.retrieve(employee.id)


### PR DESCRIPTION
Adds a new store operation that computes a delta between the before and after state of an instance.

Also fixes:
 - an issue where `created_at` was not updated properly
 - some non-realistic elements of existing update tests