### PR TITLE
Enum columns are unicode; should be inserted as such.

### DIFF
--- a/microcosm_postgres/types.py
+++ b/microcosm_postgres/types.py
@@ -25,7 +25,7 @@ class EnumType(TypeDecorator):
     def process_bind_param(self, value, dialect):
         if value is None:
             return None
-        return str(self.enum_class(value).name)
+        return unicode(self.enum_class(value).name)
 
     def process_result_value(self, value, dialect):
         if value is None:


### PR DESCRIPTION
The latest SQLAlchemy just started to produce warnings for any enum columns that used
string values:

```
SAWarning: Unicode type received non-unicode bind param value '<column>'.
```