### PR TITLE
allow parsing arbitrary query params

### DIFF
--- a/microcosm_postgres/store.py
+++ b/microcosm_postgres/store.py
@@ -184,7 +184,7 @@ class Store(object):
         """
         offset, limit = kwargs.pop("offset", None), kwargs.pop("limit", None)
 
-        crit = [getattr(self.model_class, key)==value for key, value in kwargs.iteritems()]
+        crit = [getattr(self.model_class, key) == value for key, value in kwargs.iteritems()]
         if crit:
             query = query.filter(*crit)
 

--- a/microcosm_postgres/store.py
+++ b/microcosm_postgres/store.py
@@ -182,7 +182,12 @@ class Store(object):
         :param limit: pagination limit, if any
 
         """
-        offset, limit = kwargs.get("offset"), kwargs.get("limit")
+        offset, limit = kwargs.pop("offset", None), kwargs.pop("limit", None)
+
+        crit = [getattr(self.model_class, key)==value for key, value in kwargs.iteritems()]
+        if crit:
+            query = query.filter(*crit)
+
         if offset is not None:
             query = query.offset(offset)
         if limit is not None:


### PR DESCRIPTION
I'm not sure if we want this, but as far as I can tell, the search functionality currently provided by microcosm actually ignores query params and just returns everything. 

E.g. the way the code in cresp works seems broken. The test below:
- https://github.com/globality-corp/crespi/blob/develop/crespi/tests/routes/test_box_link_routes.py#L155

only passes because right now microcosm is ignoring all query params and just returning everything and the test isn't checking that things you don't want aren't there.

It looks like microcosm-flask is passing the kwargs along properly assuming you define a custom query schema to define the allowable query params. This branch works for me against my microcosm transito:

https://github.com/globality-corp/transito/blob/feature/microcosm-config/transito/routes/account_routes.py#L40

You can run the subset of the tests I have working currently, including this search with:

` python setup.py nosetests --attr module`

on my branch transito/microcosm-config.