### PR TITLE
Add a unix timestamp base mixin.

### DIFF
--- a/microcosm_postgres/models.py
+++ b/microcosm_postgres/models.py
@@ -6,10 +6,11 @@ Every model must inherit from `Model` and should inherit from the `EntityMixin`.
 """
 from datetime import datetime
 from dateutil.tz import tzutc
+from time import time
 from uuid import uuid4
 
 from pytz import utc
-from sqlalchemy import Column, types
+from sqlalchemy import Column, Float, types
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy_utils import UUIDType
 
@@ -77,6 +78,24 @@ class PrimaryKeyMixin(object):
         return (self.updated_at.replace(tzinfo=None) - EPOCH).total_seconds()
 
 
+class UnixTimestampPrimaryKeyMixin(object):
+    """
+    Define a model with a randomized UUID primary key and tracking created/updated times.
+
+    """
+    id = Column(UUIDType(), primary_key=True, default=uuid4)
+    created_at = Column(Float, default=time, nullable=False)
+    updated_at = Column(Float, default=time, onupdate=time, nullable=False)
+
+    @property
+    def created_timestamp(self):
+        return self.created_at
+
+    @property
+    def updated_timestamp(self):
+        return self.updated_at
+
+
 class IdentityMixin(object):
     """
     Define model identity in terms of members.
@@ -132,6 +151,14 @@ class SmartMixin(object):
 
 
 class EntityMixin(PrimaryKeyMixin, IdentityMixin, SmartMixin):
+    """
+    Convention for persistent entities combining other mixins.
+
+    """
+    pass
+
+
+class UnixTimestampEntityMixin(UnixTimestampPrimaryKeyMixin, IdentityMixin, SmartMixin):
     """
     Convention for persistent entities combining other mixins.
 

--- a/microcosm_postgres/models.py
+++ b/microcosm_postgres/models.py
@@ -69,6 +69,9 @@ class PrimaryKeyMixin(object):
     created_at = Column(UTCDateTime, default=utcnow, nullable=False)
     updated_at = Column(UTCDateTime, default=utcnow, onupdate=utcnow, nullable=False)
 
+    def new_timestamp(self):
+        return utcnow()
+
     @property
     def created_timestamp(self):
         return (self.created_at.replace(tzinfo=None) - EPOCH).total_seconds()
@@ -86,6 +89,9 @@ class UnixTimestampPrimaryKeyMixin(object):
     id = Column(UUIDType(), primary_key=True, default=uuid4)
     created_at = Column(Float, default=time, nullable=False)
     updated_at = Column(Float, default=time, onupdate=time, nullable=False)
+
+    def new_timestamp(self):
+        return time()
 
     @property
     def created_timestamp(self):

--- a/microcosm_postgres/store.py
+++ b/microcosm_postgres/store.py
@@ -104,7 +104,7 @@ class Store(object):
         with self.flushing():
             instance = self.retrieve(identifier)
             self.session.merge(new_instance)
-            instance.updated_at = utcnow()
+            instance.updated_at = instance.new_timestamp()
         return instance
 
     def update_with_diff(self, identifier, new_instance):
@@ -118,7 +118,7 @@ class Store(object):
             instance = self.retrieve(identifier)
             before = Version(instance)
             self.session.merge(new_instance)
-            instance.updated_at = utcnow()
+            instance.updated_at = instance.new_timestamp()
             after = Version(instance)
         return instance, before - after
 

--- a/microcosm_postgres/store.py
+++ b/microcosm_postgres/store.py
@@ -29,7 +29,6 @@ from microcosm_postgres.errors import (
     ReferencedModelError
 )
 from microcosm_postgres.identifiers import new_object_id
-from microcosm_postgres.models import utcnow
 
 
 class Store(object):


### PR DESCRIPTION
Microcosm models were assuming a UTC datetime for created/updated timestamp.

This PR adds an alternative that just saves a Unix timestamp as float.