### PR TITLE
Enforce SSL connection to database, enable full certificate verification if desired

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 Update this file when creating new releases, with most recent releases first.
 
+## Version 0.28.0
+
+ - Introduce SSL requirement and verification options.
 
 ## Version 0.12.0
 

--- a/microcosm_postgres/factories.py
+++ b/microcosm_postgres/factories.py
@@ -30,7 +30,7 @@ MISSING = object()
     # echo all SQL
     echo="False",
     # always use SSL to connect to postgres
-    require_ssl="True",
+    require_ssl="False",
     # verify SSL certificate
     verify_ssl="False",
     # specify certificate path

--- a/microcosm_postgres/factories.py
+++ b/microcosm_postgres/factories.py
@@ -2,12 +2,14 @@
 Factory that configures SQLAlchemy for PostgreSQL.
 
 """
+from distutils.util import strtobool
+
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from microcosm.api import binding, defaults
 
-MISSING=object()
+MISSING = object()
 
 
 @binding("postgres")
@@ -69,13 +71,13 @@ def configure_sqlalchemy_engine(graph):
         pool_size=graph.config.postgres.pool_size,
         pool_timeout=graph.config.postgres.pool_timeout,
         max_overflow=graph.config.postgres.max_overflow,
-        echo=bool(graph.config.postgres.echo),
+        echo=strtobool(graph.config.postgres.echo),
         connect_args=dict(
-            sslmode="require" if graph.config.postgres.require_ssl else "prefer"
+            sslmode="require" if strtobool(graph.config.postgres.require_ssl) else "prefer"
         )
     )
 
-    if graph.config.postgres.verify_ssl and graph.config.postgres.require_ssl:
+    if strtobool(graph.config.postgres.verify_ssl) and strtobool(graph.config.postgres.require_ssl):
         if graph.config.postgres.ssl_cert_path == MISSING:
             raise
         connection_args["connect_args"] = {

--- a/microcosm_postgres/factories.py
+++ b/microcosm_postgres/factories.py
@@ -7,6 +7,8 @@ from sqlalchemy.orm import sessionmaker
 
 from microcosm.api import binding, defaults
 
+MISSING=object()
+
 
 @binding("postgres")
 @defaults(
@@ -30,7 +32,7 @@ from microcosm.api import binding, defaults
     # verify SSL certificate
     verify_ssl=False,
     # specify certificate path
-    ssl_cert_path="/path/to/my/pem",
+    ssl_cert_path=MISSING,
 )
 def configure_sqlalchemy_engine(graph):
     """
@@ -74,6 +76,8 @@ def configure_sqlalchemy_engine(graph):
     )
 
     if graph.config.postgres.verify_ssl and graph.config.postgres.require_ssl:
+        if graph.config.postgres.ssl_cert_path == MISSING:
+            raise
         connection_args["connect_args"] = {
             "sslmode": "verify-full",
             "sslrootcert": graph.config.postgres.ssl_cert_path,

--- a/microcosm_postgres/factories.py
+++ b/microcosm_postgres/factories.py
@@ -28,11 +28,11 @@ MISSING = object()
     # the number of extra connections over/above the pool size; 10 is the default
     max_overflow=10,
     # echo all SQL
-    echo=False,
+    echo="False",
     # always use SSL to connect to postgres
-    require_ssl=True,
+    require_ssl="True",
     # verify SSL certificate
-    verify_ssl=False,
+    verify_ssl="False",
     # specify certificate path
     ssl_cert_path=MISSING,
 )

--- a/microcosm_postgres/factories.py
+++ b/microcosm_postgres/factories.py
@@ -73,7 +73,7 @@ def configure_sqlalchemy_engine(graph):
         )
     )
 
-    if graph.config.postgres.verify_ssl:
+    if graph.config.postgres.verify_ssl and graph.config.postgres.require_ssl:
         connection_args["connect_args"] = {
             "sslmode": "verify-full",
             "sslrootcert": graph.config.postgres.ssl_cert_path,


### PR DESCRIPTION
This will ensure that the default connection to databases uses SSL.

The option is configurable.

In addition, we want to be able to verify the certificate from the client side,
providing a root CA available to the application.