### PR TITLE
Pluralize node names for DAG

### DIFF
--- a/microcosm_postgres/dag.py
+++ b/microcosm_postgres/dag.py
@@ -7,7 +7,7 @@ from collections import namedtuple, OrderedDict
 from inspect import getmro
 from six import add_metaclass
 
-from inflection import underscore
+from inflection import pluralize, underscore
 
 from microcosm_postgres.cloning import clone
 from microcosm_postgres.toposort import toposorted
@@ -54,7 +54,7 @@ class DAG:
         dct = dict()
         for node in self.nodes.values():
             cls = next(base for base in getmro(node.__class__) if "__tablename__" in base.__dict__)
-            key = getattr(cls, "__alias__", underscore(cls.__name__))
+            key = getattr(cls, "__alias__", underscore(pluralize(cls.__name__)))
             dct.setdefault(key, []).append(node)
         return dct
 

--- a/microcosm_postgres/tests/test_dag.py
+++ b/microcosm_postgres/tests/test_dag.py
@@ -41,6 +41,10 @@ class TestCloning(object):
             self.company.id: self.company,
             self.employee.id: self.employee,
         }))
+        assert_that(dag.nodes_map, has_entries({
+            'companies': [self.company],
+            'employees': [self.employee],
+        }))
         assert_that(dag.edges, contains(
             Edge(self.company.id, self.employee.id),
         ))


### PR DESCRIPTION
project -> projects
company -> companies

Since we have lists of items under the given nodes it makes more sense for this to be plural.