### PR TITLE
Remove python2isms

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.27.0
+current_version = 1.0.0
 commit = False
 tag = False
 

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@
 
 machine:
   python:
-      version: 2.7.11
+      version: 3.6.2
 
 general:
   artifacts:
@@ -12,7 +12,7 @@ general:
 dependencies:
   override:
     - pip install tox tox-pyenv
-    - pyenv local 2.7.11 3.5.1  # Should correspond to pre-installed Python versions on CircleCI
+    - pyenv local 3.6.2
 
 database:
   pre:

--- a/microcosm_postgres/context.py
+++ b/microcosm_postgres/context.py
@@ -8,7 +8,7 @@ from functools import wraps
 from microcosm_postgres.operations import new_session, recreate_all
 
 
-class SessionContext(object):
+class SessionContext:
     """
     Save current session in well-known location and provide context management.
 

--- a/microcosm_postgres/dag.py
+++ b/microcosm_postgres/dag.py
@@ -5,7 +5,6 @@ Directed Acyclic Graph of model objects.
 from abc import ABCMeta, abstractmethod
 from collections import namedtuple, OrderedDict
 from inspect import getmro
-from six import add_metaclass
 
 from inflection import underscore
 
@@ -87,8 +86,7 @@ class DAG:
         return DAG(nodes=nodes, substitutions=self.substitutions).build_edges()
 
 
-@add_metaclass(ABCMeta)
-class DAGCloner(object):
+class DAGCloner(metaclass=ABCMeta):
     """
     A process for building and cloning a DAG.
 

--- a/microcosm_postgres/models.py
+++ b/microcosm_postgres/models.py
@@ -60,7 +60,7 @@ class UTCDateTime(types.TypeDecorator):
             return value
 
 
-class PrimaryKeyMixin(object):
+class PrimaryKeyMixin:
     """
     Define a model with a randomized UUID primary key and tracking created/updated times.
 
@@ -81,7 +81,7 @@ class PrimaryKeyMixin(object):
         return (self.updated_at.replace(tzinfo=None) - EPOCH).total_seconds()
 
 
-class UnixTimestampPrimaryKeyMixin(object):
+class UnixTimestampPrimaryKeyMixin:
     """
     Define a model with a randomized UUID primary key and tracking created/updated times.
 
@@ -102,7 +102,7 @@ class UnixTimestampPrimaryKeyMixin(object):
         return self.updated_at
 
 
-class IdentityMixin(object):
+class IdentityMixin:
     """
     Define model identity in terms of members.
 
@@ -131,7 +131,7 @@ class IdentityMixin(object):
         return id(self) if self.id is None else hash(self.id)
 
 
-class SmartMixin(object):
+class SmartMixin:
     """
     Define a model with short cuts for CRUD operations against its `Store`.
 

--- a/microcosm_postgres/store.py
+++ b/microcosm_postgres/store.py
@@ -32,7 +32,7 @@ from microcosm_postgres.errors import (
 from microcosm_postgres.identifiers import new_object_id
 
 
-class Store(object):
+class Store:
 
     def __init__(self, graph, model_class):
         self.graph = graph

--- a/microcosm_postgres/tests/test_cloning.py
+++ b/microcosm_postgres/tests/test_cloning.py
@@ -10,7 +10,7 @@ from microcosm_postgres.context import SessionContext, transaction
 from microcosm_postgres.tests.example import Company, CompanyType
 
 
-class TestCloning(object):
+class TestCloning:
 
     def setup(self):
         self.graph = create_object_graph(name="example", testing=True, import_name="microcosm_postgres")

--- a/microcosm_postgres/tests/test_dag.py
+++ b/microcosm_postgres/tests/test_dag.py
@@ -10,7 +10,7 @@ from microcosm_postgres.dag import DAG, Edge
 from microcosm_postgres.tests.example import Company, CompanyType, Employee
 
 
-class TestCloning(object):
+class TestCloning:
 
     def setup(self):
         self.graph = create_object_graph(name="example", testing=True, import_name="microcosm_postgres")

--- a/microcosm_postgres/tests/test_example.py
+++ b/microcosm_postgres/tests/test_example.py
@@ -23,7 +23,7 @@ from microcosm_postgres.errors import (
 from microcosm_postgres.tests.example import Company, CompanyType, Employee
 
 
-class TestCompany(object):
+class TestCompany:
 
     def setup(self):
         self.graph = create_object_graph(name="example", testing=True, import_name="microcosm_postgres")
@@ -160,7 +160,7 @@ class TestCompany(object):
         assert_that(calling(company.delete), raises(ReferencedModelError))
 
 
-class TestEmployee(object):
+class TestEmployee:
 
     def setup(self):
         self.graph = create_object_graph(name="example", testing=True, import_name="microcosm_postgres")

--- a/microcosm_postgres/tests/test_identity.py
+++ b/microcosm_postgres/tests/test_identity.py
@@ -14,7 +14,7 @@ from microcosm_postgres.context import SessionContext, transaction
 from microcosm_postgres.tests.example import Company, CompanyType
 
 
-class TestIdentity(object):
+class TestIdentity:
 
     def setup(self):
         self.graph = create_object_graph(name="example", testing=True, import_name="microcosm_postgres")

--- a/microcosm_postgres/tests/test_toposort.py
+++ b/microcosm_postgres/tests/test_toposort.py
@@ -8,7 +8,7 @@ from microcosm_postgres.dag import Edge
 from microcosm_postgres.toposort import toposorted
 
 
-class Node(object):
+class Node:
     def __init__(self, id):
         self.id = id
 

--- a/microcosm_postgres/tests/test_types.py
+++ b/microcosm_postgres/tests/test_types.py
@@ -22,7 +22,7 @@ class Sequential(EntityMixin, Model):
     value = Column(Serial, server_default=FetchedValue(), nullable=False)
 
 
-class TestSequential(object):
+class TestSequential:
 
     def setup(self):
         self.graph = create_object_graph(name="example", testing=True, import_name="microcosm_postgres")

--- a/microcosm_postgres/types.py
+++ b/microcosm_postgres/types.py
@@ -3,7 +3,6 @@ Custom types.
 
 """
 from enum import Enum
-from six import text_type
 
 from sqlalchemy.types import TypeDecorator, Unicode, UserDefinedType
 
@@ -29,8 +28,8 @@ class EnumType(TypeDecorator):
         if value is None:
             return None
         if isinstance(value, Enum):
-            return text_type(self.enum_class(value).name)
-        return text_type(self.enum_class[value].name)
+            return str(self.enum_class(value).name)
+        return str(self.enum_class[value].name)
 
     def process_result_value(self, value, dialect):
         if value is None:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages, setup
 
 project = "microcosm-postgres"
-version = "0.27.0"
+version = "1.0.0"
 
 setup(
     name=project,
@@ -16,13 +16,13 @@ setup(
     zip_safe=False,
     keywords="microcosm",
     install_requires=[
-        "alembic>=0.8.4",
-        "microcosm>=0.17.0",
-        "psycopg2>=2.6.1",
-        "python_dateutil>=2.5.0",
-        "pytz>=2016.3",
-        "sqlalchemy>=1.0.12",
-        "SQLAlchemy-Utils>=0.31.6",
+        "alembic>=0.9.6",
+        "microcosm>=2.0.0",
+        "psycopg2>=2.7.3.2",
+        "python_dateutil>=2.6.1",
+        "pytz>=2017.3",
+        "SQLAlchemy>=1.2.0",
+        "SQLAlchemy-Utils>=0.32.21",
     ],
     setup_requires=[
         "nose>=1.3.6",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, lint
+envlist = py36, lint
 
 [testenv]
 commands =
@@ -10,7 +10,7 @@ deps =
 
 [testenv:lint]
 commands=flake8 microcosm_postgres
-basepython=python2.7
+basepython=python3.6
 deps=
     flake8
     flake8-print


### PR DESCRIPTION
 - Build only 3.6
 - Remove six usage
 - Remove legacy class-object inheritance
 - Bump major version