### PR TITLE
order_by created_at

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.5.0
+current_version = 1.5.1
 commit = False
 tag = False
 

--- a/microcosm_postgres/store.py
+++ b/microcosm_postgres/store.py
@@ -199,10 +199,10 @@ class Store:
         """
         Add an order by clause to a (search) query.
 
-        By default, is a noop.
+        By default, is by created_at.
 
         """
-        return query
+        return query.order_by(self.model_class.created_at.desc())
 
     def _filter(self, query, **kwargs):
         """

--- a/microcosm_postgres/tests/test_employee_store.py
+++ b/microcosm_postgres/tests/test_employee_store.py
@@ -279,3 +279,25 @@ class TestEmployeeStore:
         assert_that(retrieved_real_employee.last, is_(equal_to("Doe")))
         retrieved_fake_employee = self.employee_store.search_first(first="Tarzan")
         assert_that(retrieved_fake_employee, is_(equal_to(None)))
+
+    def test_search_ofer_by(self):
+        """
+        Should be sorted by created_at in descending order.
+
+        """
+        with transaction():
+            employee1 = Employee(
+                first="first",
+                last="last",
+                company_id=self.company.id,
+            ).create()
+            employee2 = Employee(
+                first="Jane",
+                last="Doe",
+                company_id=self.company.id,
+            ).create()
+
+        assert_that(
+            [employee.id for employee in self.employee_store.search()],
+            contains(employee2.id, employee1.id)
+        )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages, setup
 
 project = "microcosm-postgres"
-version = "1.5.0"
+version = "1.5.1"
 
 setup(
     name=project,


### PR DESCRIPTION
Update store to order results by `created_at`
Why?
To return results in the same order - useful for pagination (see `_filter` function)