### PR TITLE
Add get_current_head health check

### DIFF
--- a/microcosm_postgres/health.py
+++ b/microcosm_postgres/health.py
@@ -2,6 +2,8 @@
 Simple Postgres health check.
 
 """
+from alembic.script import ScriptDirectory
+
 from microcosm_postgres.context import SessionContext
 
 
@@ -23,3 +25,12 @@ def check_alembic(graph):
     return SessionContext.session.execute(
         "SELECT version_num FROM alembic_version LIMIT 1;",
     ).scalar()
+
+
+def get_current_head_version(graph):
+    """
+    Returns the current head version.
+
+    """
+    script_dir = ScriptDirectory("/", version_locations=[graph.metadata.get_path("migrations")])
+    return script_dir.get_current_head()


### PR DESCRIPTION
- add health check function that returns the current head version

Why?

Exposing the current head version to the health check will make it easy
to determine if the database is caught up on migrations.