### PR TITLE
Support temporary tables, especially for bulk upsert

### DIFF
--- a/microcosm_postgres/temporary/__init__.py
+++ b/microcosm_postgres/temporary/__init__.py
@@ -1,0 +1,1 @@
+from microcosm_postgres.temporary.context import transient  # noqa: F401

--- a/microcosm_postgres/temporary/context.py
+++ b/microcosm_postgres/temporary/context.py
@@ -1,0 +1,21 @@
+"""
+Transient table context manager.
+
+"""
+from contextlib import contextmanager
+
+from microcosm_postgres.context import SessionContext
+from microcosm_postgres.temporary.factories import create_transient_table
+
+
+@contextmanager
+def transient(from_table):
+    if not SessionContext.session:
+        raise Exception("transient() must be called within a SessionContext")
+
+    transient_table = create_transient_table(from_table)
+
+    bind = SessionContext.session.connection()
+    transient_table.create(bind=bind)
+
+    yield transient_table

--- a/microcosm_postgres/temporary/factories.py
+++ b/microcosm_postgres/temporary/factories.py
@@ -1,0 +1,57 @@
+"""
+Temporary table support.
+
+"""
+from types import MethodType
+
+from microcosm_postgres.temporary.methods import (
+    insert_many,
+    select_from,
+    upsert_into,
+)
+
+
+def create_temporary_table(from_table, name=None, on_commit=None):
+    """
+    Create a new temporary table from another table.
+
+    """
+    from_table = from_table.__table__ if hasattr(from_table, "__table__") else from_table
+
+    metadata = from_table.metadata
+    name = name or f"temporary_{from_table.name}"
+
+    # copy the origin table into the metadata with the new name.
+    if name in metadata.tables:
+        temporary_table = metadata.tables[name]
+    else:
+        temporary_table = from_table.tometadata(
+            metadata=metadata,
+            name=name,
+        )
+
+    # change create clause to: CREATE TEMPORARY TABLE
+    temporary_table._prefixes = list(from_table._prefixes)
+    temporary_table._prefixes.append("TEMPORARY")
+
+    # change post create clause to: ON COMMIT DROP
+    if on_commit:
+        temporary_table.dialect_options["postgresql"].update(
+            on_commit=on_commit,
+        )
+
+    temporary_table.insert_many = MethodType(insert_many, temporary_table)
+    temporary_table.select_from = MethodType(select_from, temporary_table)
+    temporary_table.upsert_into = MethodType(upsert_into, temporary_table)
+
+    return temporary_table
+
+
+def create_transient_table(from_table, name=None):
+    """
+    Create a transient table.
+
+    The transient table will be dropped on commit.
+
+    """
+    return create_temporary_table(from_table, name=name, on_commit="drop")

--- a/microcosm_postgres/temporary/methods.py
+++ b/microcosm_postgres/temporary/methods.py
@@ -1,0 +1,42 @@
+"""
+Extension methods on top of a temporary table.
+
+"""
+from microcosm_postgres.context import SessionContext
+from sqlalchemy.dialects.postgresql import insert
+
+
+def insert_many(self, items):
+    """
+    Insert many items at once into a temporary table.
+
+    Items are expected to extend `IdentityMixin`
+
+    """
+    return SessionContext.session.execute(
+        self.insert(values=[
+            item._members()
+            for item in items
+        ]),
+    ).rowcount
+
+
+def upsert_into(self, table):
+    """
+    Upsert from a temporarty table into another table.
+
+    """
+    return SessionContext.session.execute(
+        insert(table).from_select(
+            self.c,
+            self,
+        ).on_conflict_do_nothing(),
+    ).rowcount
+
+
+def select_from(self, table):
+    return SessionContext.session.query(
+        table
+    ).filter(
+        table.id == self.c.id,
+    ).all()

--- a/microcosm_postgres/tests/temporary/test_temporary.py
+++ b/microcosm_postgres/tests/temporary/test_temporary.py
@@ -1,0 +1,90 @@
+from hamcrest import (
+    assert_that,
+    contains,
+    has_properties,
+    equal_to,
+    is_,
+)
+from microcosm.api import create_object_graph
+
+from microcosm_postgres.context import SessionContext, transaction
+from microcosm_postgres.temporary import transient
+from microcosm_postgres.tests.fixtures.company import Company, CompanyType
+
+
+class TestTransient:
+
+    def setup(self):
+        self.graph = create_object_graph(
+            name="example",
+            testing=True,
+            import_name="microcosm_postgres",
+        )
+        self.company_store = self.graph.company_store
+
+        self.companies = [
+            Company(
+                name="name1",
+                type=CompanyType.private,
+            ),
+            Company(
+                name="name2",
+                type=CompanyType.private,
+            ),
+            Company(
+                name="name3",
+                type=CompanyType.private,
+            ),
+        ]
+
+        with SessionContext(self.graph) as context:
+            context.recreate_all()
+
+    def test_upsert_into(self):
+        with SessionContext(self.graph):
+            with transaction():
+                # NB: create() will set the id of companies[0]
+                self.companies[0].create()
+
+            with transaction():
+                with transient(Company) as transient_company:
+                    assert_that(
+                        transient_company.insert_many(self.companies),
+                        is_(equal_to(3)),
+                    )
+                    assert_that(
+                        transient_company.upsert_into(Company),
+                        is_(equal_to(2)),
+                    )
+                    assert_that(
+                        self.company_store.count(),
+                        is_(equal_to(3)),
+                    )
+
+    def test_select_from_none(self):
+        with SessionContext(self.graph):
+            with transient(Company) as transient_company:
+                assert_that(
+                    transient_company.select_from(Company),
+                    contains(),
+                )
+
+    def test_select_from_partial(self):
+        with SessionContext(self.graph):
+            with transaction():
+                with transient(Company) as transient_company:
+                    transient_company.insert_many(self.companies)
+                    self.companies[0].create()
+                    transient_company.upsert_into(Company)
+
+                assert_that(
+                    transient_company.select_from(Company),
+                    contains(
+                        has_properties(
+                            name="name2",
+                        ),
+                        has_properties(
+                            name="name3",
+                        ),
+                    )
+                )


### PR DESCRIPTION
One of the most effective ways to load large amounts of postgres data is to
use a bulk upsert. However, in the likely event that you want to know which
of the original records were inserted (vs ignored on conflict), it's helpful
to have a temporary table to insert from and then query for id matches.

Usage:

    # create a transient table that copies Target (using "on commit drop")
    with transient(Target) as transient_table:

        # insert many Target instances
        transient_table.insert_many([Target(...), Target(...), ...])

        # copy records from transient table into Target
        transient_table.copy_into(Target)

        # return the Target instances that were inserted
        return transient_table.select_from(TargetModel)