### PR TITLE
Cleanup metadata references

### DIFF
--- a/microcosm_postgres/temporary/context.py
+++ b/microcosm_postgres/temporary/context.py
@@ -18,4 +18,7 @@ def transient(from_table):
     bind = SessionContext.session.connection()
     transient_table.create(bind=bind)
 
-    yield transient_table
+    try:
+        yield transient_table
+    finally:
+        transient_table.metadata.remove(transient_table)

--- a/setup.py
+++ b/setup.py
@@ -16,12 +16,12 @@ setup(
     zip_safe=False,
     keywords="microcosm",
     install_requires=[
-        "alembic>=0.9.9",
-        "microcosm>=2.4.0",
-        "psycopg2-binary>=2.7.4",
+        "alembic>=1.0.0",
+        "microcosm>=2.4.1",
+        "psycopg2-binary>=2.7.5",
         "python-dateutil>=2.7.3",
-        "pytz>=2018.4",
-        "SQLAlchemy>=1.2.7",
+        "pytz>=2018.5",
+        "SQLAlchemy>=1.2.11",
         "SQLAlchemy-Utils>=0.33.3",
     ],
     setup_requires=[


### PR DESCRIPTION
Under some circumstances, failure to clean up these references causes subsequent
unit tests to fail when running `recreateall`