### PR TITLE
Remove pagination out of filter

### DIFF
--- a/microcosm_postgres/store.py
+++ b/microcosm_postgres/store.py
@@ -177,6 +177,8 @@ class Store:
         query = self._query(*criterion)
         query = self._order_by(query, **kwargs)
         query = self._filter(query, **kwargs)
+        # NB: pagination must go last
+        query = self._paginate(query, **kwargs)
         return query.all()
 
     def search_first(self, *criterion, **kwargs):
@@ -187,6 +189,8 @@ class Store:
         query = self._query(*criterion)
         query = self._order_by(query, **kwargs)
         query = self._filter(query, **kwargs)
+        # NB: pagination must go last
+        query = self._paginate(query, **kwargs)
         return query.first()
 
     def expunge(self, instance):
@@ -210,8 +214,6 @@ class Store:
 
         """
         query = self._auto_filter(query, **kwargs)
-        # NB: pagination must go last
-        query = self._paginate(query, **kwargs)
         return query
 
     def _auto_filter(self, query, **kwargs):

--- a/microcosm_postgres/tests/test_company_store.py
+++ b/microcosm_postgres/tests/test_company_store.py
@@ -107,6 +107,10 @@ class TestCompany:
             company2 = Company(name="name2").create()
 
         assert_that(Company.count(), is_(equal_to(2)))
+
+        # Pagination fields do not affect count calculations
+        assert_that(self.company_store.count(offset=1, limit=1), is_(equal_to(2)))
+
         assert_that([company.id for company in Company.search()], contains_inanyorder(company1.id, company2.id))
 
     def test_create_update_company(self):


### PR DESCRIPTION
Why?

The count call to the store should not have pagination factored in. This is typically done at the CRUDStoreAdaptor level in microcosm-flask (by just avoiding passing in limit/offset to the store's count function) but more accurately should be done in the store. Also makes it consistent with microcosm-sqlite