### PR TITLE
Ignore nested models in entity identity

### DIFF
--- a/microcosm_postgres/models.py
+++ b/microcosm_postgres/models.py
@@ -118,7 +118,8 @@ class IdentityMixin:
         return {
             key: value
             for key, value in self.__dict__.items()
-            if not key.startswith("_")
+            # NB: ignore internal SQLAlchemy state and nested relationships
+            if not key.startswith("_") and not isinstance(value, Model)
         }
 
     def __eq__(self, other):

--- a/microcosm_postgres/tests/encryption/test_models.py
+++ b/microcosm_postgres/tests/encryption/test_models.py
@@ -99,6 +99,16 @@ class TestEncryptable:
                 ),
             )
             assert_that(
+                encryptable._members(),
+                is_(equal_to(dict(
+                    created_at=encryptable.created_at,
+                    encrypted_id=encryptable.encrypted_id,
+                    id=encryptable.id,
+                    key=encryptable.key,
+                    updated_at=encryptable.updated_at,
+                ))),
+            )
+            assert_that(
                 self.encryptable_store.count(), is_(equal_to(1)),
             )
             assert_that(


### PR DESCRIPTION
If models use `relationship`, `_members` will include child rows; doing so is
both unecessary (assuming a foreign key id) and potentially breaks some upsert
usages that operate over `_members`.