### PR TITLE
Encryption: Delete and Update examples

### DIFF
--- a/microcosm_postgres/encryption/models.py
+++ b/microcosm_postgres/encryption/models.py
@@ -83,8 +83,13 @@ class EncryptableMixin:
 
     """
     __encryptor__ = None
+    __encrypted_identifier__ = "encrypted_id"
     __encryption_context_key__ = "key"
     __plaintext__ = "value"
+
+    @property
+    def encrypted_identifier(self) -> str:
+        return getattr(self, self.__encrypted_identifier__)
 
     @property
     def encryption_context_key(self) -> Optional[str]:

--- a/microcosm_postgres/encryption/store.py
+++ b/microcosm_postgres/encryption/store.py
@@ -1,0 +1,24 @@
+from microcosm_postgres.store import Store
+
+
+class EncryptableStore(Store):
+    """
+    A store for (conditionally) encryptable model.
+
+    The store supports delete action for encryptable models by deleting
+    the encrypted model.
+    Note: in order to use the store, the model must define:
+    -  An `encrypted_identifier` property (defaults to `self.encrypted_id`)
+
+    """
+
+    def __init__(self, graph, model_class, encrypted_store, **kwargs):
+        super().__init__(graph, model_class, **kwargs)
+        self.encrypted_store = encrypted_store
+
+    def delete(self, identifier):
+        instance = self.retrieve(identifier)
+        result = super().delete(identifier)
+        if instance.encrypted_identifier:
+            self.encrypted_store.delete(instance.encrypted_identifier)
+        return result

--- a/microcosm_postgres/tests/encryption/fixtures/encrpytable.py
+++ b/microcosm_postgres/tests/encryption/fixtures/encrpytable.py
@@ -31,7 +31,7 @@ class Encryptable(EntityMixin, EncryptableMixin, Model):
     # load and update encrypted relationship automatically
     encrypted = relationship(
         Encrypted,
-        cascade="delete-orphan, expunge, merge, save-update",
+        cascade="expunge, merge, save-update",
         lazy="joined",
         single_parent=True,
     )

--- a/microcosm_postgres/tests/encryption/fixtures/encrpytable.py
+++ b/microcosm_postgres/tests/encryption/fixtures/encrpytable.py
@@ -8,6 +8,7 @@ from sqlalchemy_utils import UUIDType
 from microcosm_postgres.models import EntityMixin, Model
 from microcosm_postgres.store import Store
 from microcosm_postgres.encryption.models import EncryptableMixin, EncryptedMixin
+from microcosm_postgres.encryption.store import EncryptableStore
 
 
 class Encrypted(EntityMixin, EncryptedMixin, Model):
@@ -27,8 +28,13 @@ class Encryptable(EntityMixin, EncryptableMixin, Model):
     value = Column(String, nullable=True)
     # foreign key to encrypted data
     encrypted_id = Column(UUIDType, ForeignKey("encrypted.id"), nullable=True)
-    # load encrypted relationship automatically
-    encrypted = relationship(Encrypted, lazy="joined")
+    # load and update encrypted relationship automatically
+    encrypted = relationship(
+        Encrypted,
+        cascade="delete-orphan, expunge, merge, save-update",
+        lazy="joined",
+        single_parent=True,
+    )
 
     __table_args__ = (
         CheckConstraint(
@@ -62,15 +68,7 @@ class EncryptedStore(Store):
 
 
 @binding("encryptable_store")
-class EncryptableStore(Store):
+class EncryptableModelStore(EncryptableStore):
 
     def __init__(self, graph):
-        super().__init__(graph, Encryptable)
-        self.encrypted_store = graph.encrypted_store
-
-    def delete(self, identifier):
-        instance = self.retrieve(identifier)
-        result = super().delete(identifier)
-        if instance.encrypted_id:
-            self.encrypted_store.delete(instance.encrypted_id)
-        return result
+        super().__init__(graph, Encryptable, graph.encrypted_store)


### PR DESCRIPTION
sqlalchemy relationship should allows to easily update/delete encrypted_model in respond to changes in model. This should allow us to delete orphans rows and to easily update models. This is a sqlalchemy function, not psql.

See: https://docs.sqlalchemy.org/en/latest/orm/cascades.html


* We can support update using `cascade`
* Because the way that the foreign keys our describes models are built (see examples) the `delete cascade` won't work. For now, we can move this functionality to the store (It was already there in the example)
* Maybe in a future version we will change the foreign keys constraints and discard the store