### PR TITLE
 Smart EncryptableStore.update

### DIFF
--- a/microcosm_postgres/encryption/store.py
+++ b/microcosm_postgres/encryption/store.py
@@ -1,3 +1,6 @@
+from sqlalchemy.inspection import inspect
+
+from microcosm_postgres.encryption.models import decrypt_instance
 from microcosm_postgres.store import Store
 
 
@@ -8,7 +11,8 @@ class EncryptableStore(Store):
     The store supports delete action for encryptable models by deleting
     the encrypted model.
     Note: in order to use the store, the model must define:
-    -  An `encrypted_identifier` property (defaults to `self.encrypted_id`)
+    -  An `encrypted_identifier` property (defaults to `encrypted_id`)
+    -  An `encrypted_relationship` property (defaults to `encrypted`)
 
     """
 
@@ -22,3 +26,58 @@ class EncryptableStore(Store):
         if instance.encrypted_identifier:
             self.encrypted_store.delete(instance.encrypted_identifier)
         return result
+
+    def update(self, identifier, new_instance):
+        """
+        Update an encryptable field, make sure that:
+        * We won't change the encryption context key
+        * The new value is going to be encrypted
+        * The return instance.plaintext is the updated one
+
+        Note: Will expunge the returned instance
+
+        """
+        old_instance = self.retrieve(identifier)
+        old_encrypted_identifier = old_instance.encrypted_identifier
+
+        if all(
+            new_instance.encryption_context_key and
+            old_instance.encryption_context_key != new_instance.encryption_context_key
+        ):
+            raise ValueError("Cannot change encryption context key")
+
+        # If updating a non encrypted field - skip
+        if new_instance.plaintext is None and new_instance.encrypted_relationship is None:
+            result = super().update(identifier, new_instance)
+            self.expunge(result)
+            return result
+
+        # Verify that the new instance is encrypted if it should be
+        # If it's not - encrypt it with the old key
+        # If it is - save the expected new plaintext
+        if new_instance.plaintext is not None:
+            expected_new_plaintext = new_instance.plaintext
+            new_instance = self.reencrypt_instance(new_instance, old_instance.encryption_context_key)
+        else:
+            expected_new_plaintext = decrypt_instance(new_instance)
+
+        result = super().update(identifier, new_instance)
+
+        # Delete the old encrypted value (instead of using sqlalchemy cascade)
+        if old_encrypted_identifier != new_instance.encrypted_identifier:
+            self.encrypted_store.delete(old_encrypted_identifier)
+
+        # Update the return result, super().update() won't do it.
+        self.expunge(result)
+        result.plaintext = expected_new_plaintext
+        return result
+
+    def reencrypt_instance(self, instance, encryption_context_key):
+        mapper = inspect(self.model_class)
+        values = {
+            key: value for
+            key, value in instance.__dict__.items()
+            if key in mapper.c
+        }
+        values[self.model_class.__encryption_context_key__] = encryption_context_key
+        return self.model_class(**values)

--- a/microcosm_postgres/tests/encryption/fixtures/encryptable.py
+++ b/microcosm_postgres/tests/encryption/fixtures/encryptable.py
@@ -1,0 +1,72 @@
+from typing import Sequence, Tuple
+
+from microcosm.api import binding
+from sqlalchemy import CheckConstraint, Column, ForeignKey, String
+from sqlalchemy.orm import relationship
+from sqlalchemy_utils import UUIDType
+
+from microcosm_postgres.models import EntityMixin, Model
+from microcosm_postgres.store import Store
+from microcosm_postgres.encryption.models import EncryptableMixin, EncryptedMixin
+from microcosm_postgres.encryption.store import EncryptableStore
+
+
+class Encrypted(EntityMixin, EncryptedMixin, Model):
+    __tablename__ = "encrypted"
+
+
+class Encryptable(EntityMixin, EncryptableMixin, Model):
+    """
+    A model for conditionally-encrypted plaintext.
+
+    """
+    __tablename__ = "encryptable"
+
+    # key used for encryption context
+    key = Column(String, nullable=False)
+    # value is not encrypted
+    value = Column(String, nullable=True)
+    # foreign key to encrypted data
+    encrypted_id = Column(UUIDType, ForeignKey("encrypted.id"), nullable=True)
+    # load and update encrypted relationship automatically
+    encrypted = relationship(
+        Encrypted,
+        lazy="joined",
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            name="value_or_encrypted_is_not_null",
+            sqltext="value IS NOT NULL OR encrypted_id IS NOT NULL",
+        ),
+        CheckConstraint(
+            name="value_or_encrypted_is_null",
+            sqltext="value IS NULL OR encrypted_id IS NULL",
+        ),
+    )
+
+    @property
+    def ciphertext(self) -> Tuple[bytes, Sequence[str]]:
+        return (self.encrypted.ciphertext, self.encrypted.key_ids)
+
+    @ciphertext.setter
+    def ciphertext(self, value: Tuple[bytes, Sequence[str]]) -> None:
+        ciphertext, key_ids = value
+        self.encrypted = Encrypted(
+            ciphertext=ciphertext,
+            key_ids=key_ids,
+        )
+
+
+@binding("encrypted_store")
+class EncryptedStore(Store):
+
+    def __init__(self, graph):
+        super().__init__(graph, Encrypted)
+
+
+@binding("encryptable_store")
+class EncryptableModelStore(EncryptableStore):
+
+    def __init__(self, graph):
+        super().__init__(graph, Encryptable, graph.encrypted_store)

--- a/microcosm_postgres/tests/encryption/fixtures/json_encryptable.py
+++ b/microcosm_postgres/tests/encryption/fixtures/json_encryptable.py
@@ -32,9 +32,7 @@ class JsonEncryptable(EntityMixin, EncryptableMixin, Model):
     # load and update encrypted relationship automatically
     encrypted = relationship(
         JsonEncrypted,
-        cascade="expunge, merge, save-update",
         lazy="joined",
-        single_parent=True,
     )
 
     __table_args__ = (


### PR DESCRIPTION
EncryptableStore.update is going to support seamlessly update:
The controller won't have to
* Change the encryption context key
* Reset encrypted value
* Set instance.plaintext to the updated one (The controller should still set it for the `create`), we should still need to find the right pattern here.

Also, we won't use `cascade` anymore that gave inconsistent results - per @sethisernhagen recommendation 