### PR TITLE
Add encrypted ID search

### DIFF
--- a/microcosm_postgres/encryption/store.py
+++ b/microcosm_postgres/encryption/store.py
@@ -81,3 +81,13 @@ class EncryptableStore(Store):
         }
         values[self.model_class.__encryption_context_key__] = encryption_context_key
         return self.model_class(**values)
+
+    def search_encrypted_ids(self, context_id):
+        query = self.session.query(
+            self.model_class.id,
+        ).filter(
+            getattr(self.model_class, self.model_class.__encrypted_identifier__) != None,  # noqa
+            getattr(self.model_class, self.model_class.__encryption_context_key__) == context_id,
+        )
+
+        return query.all()

--- a/microcosm_postgres/tests/encryption/test_models.py
+++ b/microcosm_postgres/tests/encryption/test_models.py
@@ -1,4 +1,5 @@
 from hamcrest import (
+    all_of,
     assert_that,
     calling,
     equal_to,
@@ -361,4 +362,28 @@ class TestEncryptable:
             )
             assert_that(
                 self.nullable_encrypted_store.count(), is_(equal_to(1)),
+            )
+
+    def test_search_encrypted_ids(self):
+        with SessionContext(self.graph):
+            with transaction():
+                encryptable = self.encryptable_store.create(
+                    Encryptable(
+                        key="private",
+                        value="value",
+                    ),
+                )
+                self.encryptable_store.create(
+                    Encryptable(
+                        key="key",
+                        value="value",
+                    ),
+                )
+
+            encrypted_ids = self.encryptable_store.search_encrypted_ids("private")
+            assert_that(
+                all_of(
+                    len(encrypted_ids), is_(equal_to(1)),
+                    encrypted_ids[0].id, is_(equal_to(encryptable.id))
+                )
             )


### PR DESCRIPTION
This is an optimization to be able to fetch all IDs that have been
encrypted without needing to load up all of the encrypted data at the
same time.