### PR TITLE
Expose the synchronize session delete param.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@
 defaults: &defaults
   working_directory: ~/repo
   docker:
-    - image: ${AWS_ECR_DOMAIN}/globality-build:2019.14.1
+    - image: ${AWS_ECR_DOMAIN}/globality-build:2019.23.2
       aws_auth:
         aws_access_key_id: ${AWS_ACCESS_KEY_ID}
         aws_secret_access_key: ${AWS_SECRET_ACCESS_KEY}
@@ -28,7 +28,7 @@ defaults: &defaults
 deploy_defaults: &deploy_defaults
   working_directory: ~/repo
   docker:
-    - image: ${AWS_ECR_DOMAIN}/globality-build:2019.14.1
+    - image: ${AWS_ECR_DOMAIN}/globality-build:2019.23.2
       aws_auth:
         aws_access_key_id: ${AWS_ACCESS_KEY_ID}
         aws_secret_access_key: ${AWS_SECRET_ACCESS_KEY}
@@ -146,8 +146,10 @@ jobs:
             echo "username:$PYPI_USERNAME" >> ~/.pypirc
             echo "password:$PYPI_PASSWORD" >> ~/.pypirc
             echo >> ~/.pypirc
+            version=$(cat .bumpversion.cfg | awk '/current_version / {print $3}')
             python setup.py register -r pypi
-            python setup.py sdist upload -r pypi
+            python setup.py sdist
+            twine upload --repository pypi dist/microcosm_postgres-${version}.tar.gz
 
 workflows:
   version: 2

--- a/.globality/build.json
+++ b/.globality/build.json
@@ -8,5 +8,5 @@
     }
   },
   "type": "python-library",
-  "version": "2019.14.1"
+  "version": "2019.23.2"
 }

--- a/microcosm_postgres/store.py
+++ b/microcosm_postgres/store.py
@@ -253,17 +253,22 @@ class Store:
                 error,
             )
 
-    def _delete(self, *criterion):
+    def _delete(self, *criterion, synchronize_session="evaluate"):
         """
         Delete a model by some criterion.
 
         Avoids race-condition check-then-delete logic by checking the count of affected rows.
 
+        NB: The `synchronize_session` keyword param is inherited from
+        sqlalchemy.delete to control how sqlalchemy computes the set of rows to
+        delete. This can be important for efficiency as well as flexibility. For more details see:
+        https://docs.sqlalchemy.org/en/13/orm/query.html?highlight=delete#sqlalchemy.orm.query.Query.delete
+
         :raises `ResourceNotFound` if the row cannot be deleted.
 
         """
         with self.flushing():
-            count = self._query(*criterion).delete()
+            count = self._query(*criterion).delete(synchronize_session=synchronize_session)
         if count == 0:
             raise ModelNotFoundError
         return True

--- a/microcosm_postgres/tests/test_company_store.py
+++ b/microcosm_postgres/tests/test_company_store.py
@@ -100,6 +100,7 @@ class TestCompany:
         """
         with transaction():
             company = Company(name="name").create()
+            other_company = Company(name="other-name").create()
 
         with transaction():
             self.company_store._delete(Company.name.in_(["name"]), synchronize_session="fetch")
@@ -108,6 +109,9 @@ class TestCompany:
             calling(Company.retrieve).with_args(company.id),
             raises(ModelNotFoundError, pattern="Company not found"),
         )
+
+        assert_that(Company.count(), is_(equal_to(1)))
+
 
     def test_create_search_count_company(self):
         """

--- a/microcosm_postgres/tests/test_company_store.py
+++ b/microcosm_postgres/tests/test_company_store.py
@@ -95,7 +95,7 @@ class TestCompany:
 
     def test_create_delete_company_complicated_expression(self):
         """
-        Should not be able to retrieve a company after deleting it.
+        Delete should support more complicated criterion with the `fetch` synchronization strategy enabled.
 
         """
         with transaction():

--- a/microcosm_postgres/tests/test_company_store.py
+++ b/microcosm_postgres/tests/test_company_store.py
@@ -93,6 +93,22 @@ class TestCompany:
             raises(ModelNotFoundError, pattern="Company not found"),
         )
 
+    def test_create_delete_company_complicated_expression(self):
+        """
+        Should not be able to retrieve a company after deleting it.
+
+        """
+        with transaction():
+            company = Company(name="name").create()
+
+        with transaction():
+            self.company_store._delete(Company.name.in_(["name"]), synchronize_session="fetch")
+
+        assert_that(
+            calling(Company.retrieve).with_args(company.id),
+            raises(ModelNotFoundError, pattern="Company not found"),
+        )
+
     def test_create_search_count_company(self):
         """
         Should be able to search and count companies after creation.

--- a/microcosm_postgres/tests/test_company_store.py
+++ b/microcosm_postgres/tests/test_company_store.py
@@ -100,7 +100,7 @@ class TestCompany:
         """
         with transaction():
             company = Company(name="name").create()
-            other_company = Company(name="other-name").create()
+            Company(name="other-name").create()
 
         with transaction():
             self.company_store._delete(Company.name.in_(["name"]), synchronize_session="fetch")
@@ -111,7 +111,6 @@ class TestCompany:
         )
 
         assert_that(Company.count(), is_(equal_to(1)))
-
 
     def test_create_search_count_company(self):
         """


### PR DESCRIPTION
Why? SqlAlchemy `delete` attemps to synchronize the session before the
commit. It does so by taking a middle ground between performance and
convenience, but it also exposes other strategies based on the use case.
This PR exposes those other strategies for other use cases that may
arise.

The default `evaluate` is nice, but the way the store is written
requires overwriting the built-in `_delete` method to gain access to the
other `sqlalchemy` session synch strategies. This matters because the
other strategies (no strategy and `fetch`) are more efficient and more
convenient respectively.