### PR TITLE
GLOB-38849: added metrics to postgres-store

### DIFF
--- a/microcosm_postgres/metrics.py
+++ b/microcosm_postgres/metrics.py
@@ -35,7 +35,7 @@ class PostgresStoreMetrics:
 
     def __call__(self, model_name, action, elapsed_time, execution_result):
         """
-        Send metrics for how long it takes to produce a message
+        Send metrics for how long it takes to execute a sql operation
 
         """
         if not self.enabled:

--- a/microcosm_postgres/metrics.py
+++ b/microcosm_postgres/metrics.py
@@ -1,3 +1,5 @@
+from enum import Enum
+
 from microcosm.api import defaults, typed
 from microcosm.config.types import boolean
 from microcosm.errors import NotBoundError
@@ -15,9 +17,10 @@ class PostgresStoreMetrics:
 
     def __init__(self, graph):
         self.metrics = self.get_metrics(graph)
-        self.enabled = bool(
-            self.metrics and graph.config.postgres_store_metrics.enabled
-        )
+        self.enabled = all([
+            self.metrics,
+            graph.config.postgres_store_metrics.enabled
+        ])
 
     def get_metrics(self, graph):
         """
@@ -56,7 +59,7 @@ class PostgresStoreMetrics:
         )
 
 
-class SQLExecutionStatus:
+class SQLExecutionStatus(Enum):
     SUCCESS = "SUCCESS"
     FAILURE = "FAILURE"
 
@@ -72,10 +75,10 @@ def postgres_metric_timing(action):
                 with elapsed_time(extra):
                     try:
                         result = func(self, *args, **kwargs)
-                        execution_status = SQLExecutionStatus.SUCCESS
+                        execution_status = SQLExecutionStatus.SUCCESS.name
                         return result
                     except Exception:
-                        execution_status = SQLExecutionStatus.FAILURE
+                        execution_status = SQLExecutionStatus.FAILURE.name
                         raise
             finally:
                 self.postgres_store_metrics(

--- a/microcosm_postgres/metrics.py
+++ b/microcosm_postgres/metrics.py
@@ -1,0 +1,84 @@
+from microcosm.api import defaults, typed
+from microcosm.config.types import boolean
+from microcosm.errors import NotBoundError
+from microcosm_logging.timing import elapsed_time
+
+
+@defaults(
+    enabled=typed(boolean, default_value=True)
+)
+class PostgresStoreMetrics:
+    """
+    Send metrics regarding the postgres store
+
+    """
+
+    def __init__(self, graph):
+        self.metrics = self.get_metrics(graph)
+        self.enabled = bool(
+            self.metrics
+            and self.metrics.host != "localhost"
+            and graph.config.postgres_store_metrics.enabled
+        )
+
+    def get_metrics(self, graph):
+        """
+        Fetch the metrics client from the graph.
+
+        Metrics will be disabled if the not configured.
+
+        """
+        try:
+            return graph.metrics
+        except NotBoundError:
+            return None
+
+    def __call__(self, model_name, action, elapsed_time, execution_result):
+        """
+        Send metrics for how long it takes to produce a message
+
+        """
+        if not self.enabled:
+            return
+
+        if not model_name:
+            return
+
+        key = "store"
+        tags = [
+            "source:microcosm-postgres",
+            f"result:{execution_result}",
+            f"action:{action}",
+            f"model_name:{model_name}",
+        ]
+        self.metrics.histogram(
+            key,
+            elapsed_time,
+            tags=tags,
+        )
+
+
+def postgres_metric_timing(action):
+    def wrap(func):
+        def func_wrapper(self, *args, **kwargs):
+            extra = dict(
+                model_name=self.model_name,
+                action=action
+            )
+            try:
+                with elapsed_time(extra):
+                    try:
+                        result = func(self, *args, **kwargs)
+                        execution_status = "SUCCESS"
+                        return result
+                    except Exception:
+                        execution_status = "FAILURE"
+                        raise
+            finally:
+                self.postgres_store_metrics(
+                    execution_result=execution_status,
+                    **extra
+                )
+
+        return func_wrapper
+    return wrap

--- a/microcosm_postgres/metrics.py
+++ b/microcosm_postgres/metrics.py
@@ -16,9 +16,7 @@ class PostgresStoreMetrics:
     def __init__(self, graph):
         self.metrics = self.get_metrics(graph)
         self.enabled = bool(
-            self.metrics
-            and self.metrics.host != "localhost"
-            and graph.config.postgres_store_metrics.enabled
+            self.metrics and graph.config.postgres_store_metrics.enabled
         )
 
     def get_metrics(self, graph):

--- a/microcosm_postgres/metrics.py
+++ b/microcosm_postgres/metrics.py
@@ -58,6 +58,11 @@ class PostgresStoreMetrics:
         )
 
 
+class SQLExecutionStatus:
+    SUCCESS = "SUCCESS"
+    FAILURE = "FAILURE"
+
+
 def postgres_metric_timing(action):
     def wrap(func):
         def func_wrapper(self, *args, **kwargs):
@@ -69,10 +74,10 @@ def postgres_metric_timing(action):
                 with elapsed_time(extra):
                     try:
                         result = func(self, *args, **kwargs)
-                        execution_status = "SUCCESS"
+                        execution_status = SQLExecutionStatus.SUCCESS
                         return result
                     except Exception:
-                        execution_status = "FAILURE"
+                        execution_status = SQLExecutionStatus.FAILURE
                         raise
             finally:
                 self.postgres_store_metrics(
@@ -81,4 +86,5 @@ def postgres_metric_timing(action):
                 )
 
         return func_wrapper
+
     return wrap

--- a/microcosm_postgres/tests/test_company_store.py
+++ b/microcosm_postgres/tests/test_company_store.py
@@ -11,9 +11,11 @@ from hamcrest import (
     contains_inanyorder,
     empty,
     equal_to,
+    has_entries,
+    has_key,
     is_,
     raises,
-    has_entries, has_key)
+)
 from microcosm.api import create_object_graph
 
 from microcosm_postgres.context import SessionContext, transaction

--- a/microcosm_postgres/tests/test_company_store.py
+++ b/microcosm_postgres/tests/test_company_store.py
@@ -224,16 +224,18 @@ class TestCompany:
             assert_that(mocked_metrics.call_count, is_(equal_to(2)))
             call_arg1 = mocked_metrics.call_args_list[0][1]
             call_arg2 = mocked_metrics.call_args_list[1][1]
-            assert_that(call_arg1, has_entries(dict(execution_result=equal_to(SQLExecutionStatus.SUCCESS),
-                                                    model_name=equal_to('Company'),
-                                                    action=equal_to('create')
-                                                    )))
+            assert_that(call_arg1, has_entries(dict(
+                execution_result=equal_to(SQLExecutionStatus.SUCCESS.name),
+                model_name=equal_to('Company'),
+                action=equal_to('create')
+            )))
             assert_that(call_arg1, has_key(equal_to('elapsed_time')))
 
-            assert_that(call_arg2, has_entries(dict(execution_result=equal_to(SQLExecutionStatus.SUCCESS),
-                                                    model_name=equal_to('Company'),
-                                                    action=equal_to('retrieve')
-                                                    )))
+            assert_that(call_arg2, has_entries(dict(
+                execution_result=equal_to(SQLExecutionStatus.SUCCESS.name),
+                model_name=equal_to('Company'),
+                action=equal_to('retrieve')
+            )))
             assert_that(call_arg2, has_key(equal_to('elapsed_time')))
 
     def test_create_company_create_and_delete_employee_stores_metrics(self):
@@ -259,22 +261,25 @@ class TestCompany:
                 call_arg1 = mocked_employee_metrics.call_args_list[0][1]
                 call_arg2 = mocked_employee_metrics.call_args_list[1][1]
                 call_arg3 = mocked_employee_metrics.call_args_list[2][1]
-                assert_that(call_arg1, has_entries(dict(execution_result=equal_to(SQLExecutionStatus.SUCCESS),
-                                                        model_name=equal_to('Employee'),
-                                                        action=equal_to('create')
-                                                        )))
+                assert_that(call_arg1, has_entries(dict(
+                    execution_result=equal_to(SQLExecutionStatus.SUCCESS.name),
+                    model_name=equal_to('Employee'),
+                    action=equal_to('create')
+                )))
                 assert_that(call_arg1, has_key(equal_to('elapsed_time')))
 
-                assert_that(call_arg2, has_entries(dict(execution_result=equal_to(SQLExecutionStatus.SUCCESS),
-                                                        model_name=equal_to('Employee'),
-                                                        action=equal_to('retrieve')
-                                                        )))
+                assert_that(call_arg2, has_entries(dict(
+                    execution_result=equal_to(SQLExecutionStatus.SUCCESS.name),
+                    model_name=equal_to('Employee'),
+                    action=equal_to('retrieve')
+                )))
                 assert_that(call_arg2, has_key(equal_to('elapsed_time')))
 
-                assert_that(call_arg3, has_entries(dict(execution_result=equal_to(SQLExecutionStatus.SUCCESS),
-                                                        model_name=equal_to('Employee'),
-                                                        action=equal_to('delete')
-                                                        )))
+                assert_that(call_arg3, has_entries(dict(
+                    execution_result=equal_to(SQLExecutionStatus.SUCCESS.name),
+                    model_name=equal_to('Employee'),
+                    action=equal_to('delete')
+                )))
                 assert_that(call_arg3, has_key(equal_to('elapsed_time')))
 
     def test_create_raises_exception_stores_metrics(self):
@@ -294,20 +299,23 @@ class TestCompany:
             call_arg1 = mocked_metrics.call_args_list[0][1]
             call_arg2 = mocked_metrics.call_args_list[1][1]
             call_arg3 = mocked_metrics.call_args_list[2][1]
-            assert_that(call_arg1, has_entries(dict(execution_result=equal_to(SQLExecutionStatus.SUCCESS),
-                                                    model_name=equal_to('Company'),
-                                                    action=equal_to('create')
-                                                    )))
+            assert_that(call_arg1, has_entries(dict(
+                execution_result=equal_to(SQLExecutionStatus.SUCCESS.name),
+                model_name=equal_to('Company'),
+                action=equal_to('create')
+            )))
             assert_that(call_arg1, has_key(equal_to('elapsed_time')))
 
-            assert_that(call_arg2, has_entries(dict(execution_result=equal_to(SQLExecutionStatus.FAILURE),
-                                                    model_name=equal_to('Company'),
-                                                    action=equal_to('create')
-                                                    )))
+            assert_that(call_arg2, has_entries(dict(
+                execution_result=equal_to(SQLExecutionStatus.FAILURE.name),
+                model_name=equal_to('Company'),
+                action=equal_to('create')
+            )))
             assert_that(call_arg2, has_key(equal_to('elapsed_time')))
 
-            assert_that(call_arg3, has_entries(dict(execution_result=equal_to(SQLExecutionStatus.FAILURE),
-                                                    model_name=equal_to('Company'),
-                                                    action=equal_to('delete')
-                                                    )))
+            assert_that(call_arg3, has_entries(dict(
+                execution_result=equal_to(SQLExecutionStatus.FAILURE.name),
+                model_name=equal_to('Company'),
+                action=equal_to('delete')
+            )))
             assert_that(call_arg3, has_key(equal_to('elapsed_time')))

--- a/microcosm_postgres/tests/test_company_store.py
+++ b/microcosm_postgres/tests/test_company_store.py
@@ -20,6 +20,7 @@ from microcosm.api import create_object_graph
 
 from microcosm_postgres.context import SessionContext, transaction
 from microcosm_postgres.errors import DuplicateModelError, ModelNotFoundError, ReferencedModelError
+from microcosm_postgres.metrics import SQLExecutionStatus
 from microcosm_postgres.tests.fixtures import Company, CompanyType, Employee
 
 
@@ -223,16 +224,16 @@ class TestCompany:
             assert_that(mocked_metrics.call_count, is_(equal_to(2)))
             call_arg1 = mocked_metrics.call_args_list[0][1]
             call_arg2 = mocked_metrics.call_args_list[1][1]
-            assert_that(call_arg1, has_entries({'execution_result': equal_to('SUCCESS'),
-                                                'model_name': equal_to('Company'),
-                                                'action': equal_to('create')
-                                                }))
+            assert_that(call_arg1, has_entries(dict(execution_result=equal_to(SQLExecutionStatus.SUCCESS),
+                                                    model_name=equal_to('Company'),
+                                                    action=equal_to('create')
+                                                    )))
             assert_that(call_arg1, has_key(equal_to('elapsed_time')))
 
-            assert_that(call_arg2, has_entries({'execution_result': equal_to('SUCCESS'),
-                                                'model_name': equal_to('Company'),
-                                                'action': equal_to('retrieve'),
-                                                }))
+            assert_that(call_arg2, has_entries(dict(execution_result=equal_to(SQLExecutionStatus.SUCCESS),
+                                                    model_name=equal_to('Company'),
+                                                    action=equal_to('retrieve')
+                                                    )))
             assert_that(call_arg2, has_key(equal_to('elapsed_time')))
 
     def test_create_company_create_and_delete_employee_stores_metrics(self):
@@ -258,22 +259,22 @@ class TestCompany:
                 call_arg1 = mocked_employee_metrics.call_args_list[0][1]
                 call_arg2 = mocked_employee_metrics.call_args_list[1][1]
                 call_arg3 = mocked_employee_metrics.call_args_list[2][1]
-                assert_that(call_arg1, has_entries({'execution_result': equal_to('SUCCESS'),
-                                                    'model_name': equal_to('Employee'),
-                                                    'action': equal_to('create')
-                                                    }))
+                assert_that(call_arg1, has_entries(dict(execution_result=equal_to(SQLExecutionStatus.SUCCESS),
+                                                        model_name=equal_to('Employee'),
+                                                        action=equal_to('create')
+                                                        )))
                 assert_that(call_arg1, has_key(equal_to('elapsed_time')))
 
-                assert_that(call_arg2, has_entries({'execution_result': equal_to('SUCCESS'),
-                                                    'model_name': equal_to('Employee'),
-                                                    'action': equal_to('retrieve'),
-                                                    }))
+                assert_that(call_arg2, has_entries(dict(execution_result=equal_to(SQLExecutionStatus.SUCCESS),
+                                                        model_name=equal_to('Employee'),
+                                                        action=equal_to('retrieve')
+                                                        )))
                 assert_that(call_arg2, has_key(equal_to('elapsed_time')))
 
-                assert_that(call_arg3, has_entries({'execution_result': equal_to('SUCCESS'),
-                                                    'model_name': equal_to('Employee'),
-                                                    'action': equal_to('delete'),
-                                                    }))
+                assert_that(call_arg3, has_entries(dict(execution_result=equal_to(SQLExecutionStatus.SUCCESS),
+                                                        model_name=equal_to('Employee'),
+                                                        action=equal_to('delete')
+                                                        )))
                 assert_that(call_arg3, has_key(equal_to('elapsed_time')))
 
     def test_create_raises_exception_stores_metrics(self):
@@ -293,20 +294,20 @@ class TestCompany:
             call_arg1 = mocked_metrics.call_args_list[0][1]
             call_arg2 = mocked_metrics.call_args_list[1][1]
             call_arg3 = mocked_metrics.call_args_list[2][1]
-            assert_that(call_arg1, has_entries({'execution_result': equal_to('SUCCESS'),
-                                                'model_name': equal_to('Company'),
-                                                'action': equal_to('create')
-                                                }))
+            assert_that(call_arg1, has_entries(dict(execution_result=equal_to(SQLExecutionStatus.SUCCESS),
+                                                    model_name=equal_to('Company'),
+                                                    action=equal_to('create')
+                                                    )))
             assert_that(call_arg1, has_key(equal_to('elapsed_time')))
 
-            assert_that(call_arg2, has_entries({'execution_result': equal_to('FAILURE'),
-                                                'model_name': equal_to('Company'),
-                                                'action': equal_to('create'),
-                                                }))
+            assert_that(call_arg2, has_entries(dict(execution_result=equal_to(SQLExecutionStatus.FAILURE),
+                                                    model_name=equal_to('Company'),
+                                                    action=equal_to('create')
+                                                    )))
             assert_that(call_arg2, has_key(equal_to('elapsed_time')))
 
-            assert_that(call_arg3, has_entries({'execution_result': equal_to('FAILURE'),
-                                                'model_name': equal_to('Company'),
-                                                'action': equal_to('delete'),
-                                                }))
+            assert_that(call_arg3, has_entries(dict(execution_result=equal_to(SQLExecutionStatus.FAILURE),
+                                                    model_name=equal_to('Company'),
+                                                    action=equal_to('delete')
+                                                    )))
             assert_that(call_arg3, has_key(equal_to('elapsed_time')))

--- a/microcosm_postgres/tests/test_company_store.py
+++ b/microcosm_postgres/tests/test_company_store.py
@@ -2,6 +2,8 @@
 Persistence tests for company store.
 
 """
+from unittest.mock import patch
+
 from hamcrest import (
     assert_that,
     calling,
@@ -11,7 +13,7 @@ from hamcrest import (
     equal_to,
     is_,
     raises,
-)
+    has_entries, has_key)
 from microcosm.api import create_object_graph
 
 from microcosm_postgres.context import SessionContext, transaction
@@ -203,3 +205,72 @@ class TestCompany:
             ).create()
 
         assert_that(calling(company.delete), raises(ReferencedModelError))
+
+
+    def test_create_company_stores_metrics(self):
+        with patch.object(self.graph.company_store, "postgres_store_metrics") as mocked_metrics:
+            with transaction():
+                company = Company(
+                    name="name",
+                    type=CompanyType.private,
+                ).create()
+
+            retrieved_company = Company.retrieve(company.id)
+            assert_that(retrieved_company.name, is_(equal_to("name")))
+            assert_that(retrieved_company.type, is_(equal_to(CompanyType.private)))
+
+            assert_that(mocked_metrics.call_count, is_(equal_to(2)))
+            call_arg1 = mocked_metrics.call_args_list[0][1]
+            call_arg2 = mocked_metrics.call_args_list[1][1]
+            assert_that(call_arg1, has_entries({'execution_result':equal_to('SUCCESS'),
+                                                'model_name':equal_to('Company'),
+                                                'action':equal_to('create')
+                                                }))
+            assert_that(call_arg1, has_key(equal_to('elapsed_time')))
+
+            assert_that(call_arg2, has_entries({'execution_result':equal_to('SUCCESS'),
+                                                'model_name':equal_to('Company'),
+                                                'action':equal_to('retrieve'),
+                                                }))
+            assert_that(call_arg2, has_key(equal_to('elapsed_time')))
+
+    def test_create_company_create_and_delete_employee_stores_metrics(self):
+        with patch.object(self.graph.company_store, "postgres_store_metrics") as mocked_company_metrics:
+            with patch.object(self.graph.employee_store, "postgres_store_metrics") as mocked_employee_metrics:
+                with transaction():
+                    company = Company(
+                        name="name",
+                    ).create()
+                    employee = Employee(
+                        first="first",
+                        last="last",
+                        company_id=company.id,
+                    ).create()
+                retrieved_employee = Employee.retrieve(employee.id)
+                assert_that(retrieved_employee.first, is_(equal_to("first")))
+
+                with transaction():
+                    employee.delete()
+
+                assert_that(mocked_company_metrics.call_count, is_(equal_to(1)))
+                assert_that(mocked_employee_metrics.call_count, is_(equal_to(3)))
+                call_arg1 = mocked_employee_metrics.call_args_list[0][1]
+                call_arg2 = mocked_employee_metrics.call_args_list[1][1]
+                call_arg3 = mocked_employee_metrics.call_args_list[2][1]
+                assert_that(call_arg1, has_entries({'execution_result':equal_to('SUCCESS'),
+                                                    'model_name':equal_to('Employee'),
+                                                    'action':equal_to('create')
+                                                    }))
+                assert_that(call_arg1, has_key(equal_to('elapsed_time')))
+
+                assert_that(call_arg2, has_entries({'execution_result':equal_to('SUCCESS'),
+                                                    'model_name':equal_to('Employee'),
+                                                    'action':equal_to('retrieve'),
+                                                    }))
+                assert_that(call_arg2, has_key(equal_to('elapsed_time')))
+
+                assert_that(call_arg3, has_entries({'execution_result':equal_to('SUCCESS'),
+                                                    'model_name':equal_to('Employee'),
+                                                    'action':equal_to('delete'),
+                                                    }))
+                assert_that(call_arg3, has_key(equal_to('elapsed_time')))

--- a/microcosm_postgres/tests/test_metrics.py
+++ b/microcosm_postgres/tests/test_metrics.py
@@ -31,7 +31,7 @@ def test_configure_metrics_default_metrics_installed():
         mocked.return_value = Mock(host="localhost")
 
         graph = create_object_graph("example", testing=True)
-        assert_that(graph.postgres_store_metrics.enabled, is_(equal_to(False)))
+        assert_that(graph.postgres_store_metrics.enabled, is_(equal_to(True)))
 
 
 def test_configure_metrics_default_metrics_configured():

--- a/microcosm_postgres/tests/test_metrics.py
+++ b/microcosm_postgres/tests/test_metrics.py
@@ -1,0 +1,60 @@
+"""
+Test metrics enablement.
+
+"""
+from unittest.mock import Mock, patch
+
+from hamcrest import assert_that, equal_to, is_
+from microcosm.api import create_object_graph, load_from_dict
+
+from microcosm_postgres.metrics import PostgresStoreMetrics
+
+
+def test_configure_metrics_default_metrics_not_installed():
+    """
+    Disable metrics by default if metrics not installed.
+
+    """
+    with patch.object(PostgresStoreMetrics, "get_metrics") as mocked:
+        mocked.return_value = None
+
+        graph = create_object_graph("example", testing=True)
+        assert_that(graph.postgres_store_metrics.enabled, is_(equal_to(False)))
+
+
+def test_configure_metrics_default_metrics_installed():
+    """
+    Enabled metrics by default if installed.
+
+    """
+    with patch.object(PostgresStoreMetrics, "get_metrics") as mocked:
+        mocked.return_value = Mock(host="localhost")
+
+        graph = create_object_graph("example", testing=True)
+        assert_that(graph.postgres_store_metrics.enabled, is_(equal_to(False)))
+
+
+def test_configure_metrics_default_metrics_configured():
+    """
+    Enabled metrics by default if installed.
+
+    """
+    with patch.object(PostgresStoreMetrics, "get_metrics") as mocked:
+        mocked.return_value = Mock(host="statsd")
+
+        graph = create_object_graph("example", testing=True)
+        assert_that(graph.postgres_store_metrics.enabled, is_(equal_to(True)))
+
+
+def test_configure_metrics_disable():
+    """
+    Disable metrics explicitly.
+
+    """
+    loader = load_from_dict(
+        postgres_store_metrics=dict(
+            enabled=False,
+        ),
+    )
+    graph = create_object_graph("example", testing=True, loader=loader)
+    assert_that(graph.postgres_store_metrics.enabled, is_(equal_to(False)))

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
     dependency_links=[
     ],
     extras_require={
+        "metrics": "microcosm-metrics>=2.5.0",
         "encryption": "aws-encryption-sdk>=1.3.8",
     },
     entry_points={
@@ -43,6 +44,7 @@ setup(
             "multi_tenant_key_registry = microcosm_postgres.encryption.registry:MultiTenantKeyRegistry [encryption]",
             "materials_manager = microcosm_postgres.encryption.providers:configure_materials_manager [encryption]",
             "postgres = microcosm_postgres.factories.engine:configure_engine",
+            "postgres_store_metrics = microcosm_postgres.metrics:PostgresStoreMetrics",
             "sessionmaker = microcosm_postgres.factories.sessionmaker:configure_sessionmaker",
         ],
     },

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         "microcosm>=2.12.0",
         "microcosm-logging>=1.5.0",
         "psycopg2-binary>=2.7.5",
-        "python-dateutil>=2.7.3",
+        "python-dateutil<2.8.1",
         "pytz>=2018.5",
         "SQLAlchemy>=1.2.11",
         "SQLAlchemy-Utils>=0.33.3",


### PR DESCRIPTION
Task: https://globality.atlassian.net/browse/GLOB-38849

This PR adds metrics to postgres-store layer. Operations we are capturing metrics on are: create, retrieve, update, update_with_diff, delete, count, search, search_first
