### PR TITLE
Truncate data on reset / re-use existing metadata instance

### DIFF
--- a/microcosm_postgres/operations.py
+++ b/microcosm_postgres/operations.py
@@ -2,6 +2,7 @@
 Common database operations.
 
 """
+from sqlalchemy import MetaData
 from sqlalchemy.exc import ProgrammingError
 
 from microcosm_postgres.migrate import main
@@ -65,13 +66,37 @@ def drop_alembic_table(graph):
         return True
 
 
+# Cached database metadata instance
+_metadata = None
+
+
 def recreate_all(graph):
     """
-    Drop and add back all database tables.
+    Drop and add back all database tables, or reset all data associated with a database.
+    Intended mainly for testing, where a test database may either need to be re-initialized
+    or cleared out between tests
 
     """
-    drop_all(graph)
-    create_all(graph)
+
+    global _metadata
+    initialize = False
+
+    if _metadata is None:
+        _metadata = MetaData(bind=graph.postgres, reflect=True)
+        initialize = True
+
+    # First use of this function, re-create the database from scratch.
+    if initialize:
+        drop_all(graph)
+        create_all(graph)
+        return
+
+    # Otherwise, truncate all existing tables
+    connection = graph.postgres.connect()
+    transaction = connection.begin()
+    for table in reversed(_metadata.sorted_tables):
+        connection.execute(table.delete())
+    transaction.commit()
 
 
 def new_session(graph, expire_on_commit=False):

--- a/microcosm_postgres/operations.py
+++ b/microcosm_postgres/operations.py
@@ -79,16 +79,13 @@ def recreate_all(graph):
     """
 
     global _metadata
-    initialize = False
 
     if _metadata is None:
-        _metadata = MetaData(bind=graph.postgres, reflect=True)
-        initialize = True
-
-    # First use of this function, re-create the database from scratch.
-    if initialize:
+        # First-run, the test database/metadata needs to be initialized
         drop_all(graph)
         create_all(graph)
+
+        _metadata = MetaData(bind=graph.postgres, reflect=True)
         return
 
     # Otherwise, truncate all existing tables

--- a/microcosm_postgres/tests/test_serial_type.py
+++ b/microcosm_postgres/tests/test_serial_type.py
@@ -56,11 +56,12 @@ class TestSerialType:
             with transaction():
                 example = self.store.create(WithSerial())
 
+            value = example.value
             context.session.expunge(example)
 
             example = self.store.retrieve(example.id)
 
-        assert_that(example.value, is_(equal_to(1)))
+        assert_that(example.value, is_(equal_to(value)))
 
     def test_retrieve_by_sequence_value(self):
         """
@@ -86,6 +87,7 @@ class TestSerialType:
             with transaction():
                 example = self.store.create(WithSerial())
 
+            previous_value = example.value
             example.value = example.value + 1
 
             with transaction():
@@ -95,7 +97,7 @@ class TestSerialType:
 
             example = self.store.retrieve(example.id)
 
-        assert_that(example.value, is_(equal_to(2)))
+        assert_that(example.value, is_(previous_value + 1))
 
     def test_delete_does_not_reset_sequence(self):
         """
@@ -106,10 +108,12 @@ class TestSerialType:
             with transaction():
                 example = self.store.create(WithSerial())
 
+            previous_value = example.value
+
             with transaction():
                 self.store.delete(example.id)
 
             with transaction():
                 example = self.store.create(WithSerial())
 
-            assert_that(example.value, is_(equal_to(2)))
+            assert_that(example.value, is_(equal_to(previous_value + 1)))


### PR DESCRIPTION
After analyzing some slow-running unit test runs across a few services,
it became apparent that this could be largely attributed to
creating/dropping the database in between each test case.

Namely, there is a large cost attributed with evaluating each
table/column from scratch between tests. Locally, this could table up to
half a second(!). On some repos with 500+ tests, this adds up.

This change should reduce the cost of resetting the database (after the
initial run) milliseconds.

Tested this out on a number of repos, with substantial differences:
* 873 tests: 490s => 145s
* 422 tests: 131s => 30s

To see the difference in performance, see this flame graph comparison:
Before:
<img width="904" alt="Screen Shot 2019-12-09 at 3 57 22 PM" src="https://user-images.githubusercontent.com/19560680/70483204-a1ccdf00-1a9c-11ea-83d4-4d04d4a66638.png">

After:
<img width="915" alt="Screen Shot 2019-12-09 at 3 57 30 PM" src="https://user-images.githubusercontent.com/19560680/70483215-aa251a00-1a9c-11ea-94af-3b94c95aa30e.png">

Notice how many times `recreate_all` shows up in the "before" graph (it actually shows up more than once), vastly overshadowing the actual code being tested.

Diving into why it cost so much, you can see how much of the time was actually spent in `visit_metadata`, which happens because we were essentially re-calculating this data from scratch.

In "after", `recreate_all` actually *still* dominates a bunch of operations, but its relative proportion is much lower than before. Again, digging into that same function call afterwards, you can see that it goes right into SQL code execution, rather than metadata creation.