### PR TITLE
drop python-dateutil<2.8.12 pin as upstream changes to boto-core now allow it

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
         "microcosm>=2.12.0",
         "microcosm-logging>=1.5.0",
         "psycopg2-binary>=2.7.5",
-        "python-dateutil<2.8.1",
         "pytz>=2018.5",
         "SQLAlchemy>=1.2.11",
         "SQLAlchemy-Utils>=0.33.3",


### PR DESCRIPTION
See [here](https://github.com/boto/botocore/commit/f2f12a23b7937397b34e41698c0ac2a3f0a951ba#diff-2eeaed663bd0d25b7e608891384b7298)