### PR TITLE
Add default search sorting by created_at key

### DIFF
--- a/microcosm_postgres/models.py
+++ b/microcosm_postgres/models.py
@@ -80,9 +80,9 @@ class PrimaryKeyMixin:
     def updated_timestamp(self):
         return (self.updated_at.replace(tzinfo=None) - EPOCH).total_seconds()
 
-    @property
-    def sort_key(self):
-        return self.created_at.asc()
+    @classmethod
+    def sort_by(cls):
+        return cls.created_at.asc()
 
 
 class UnixTimestampPrimaryKeyMixin:

--- a/microcosm_postgres/models.py
+++ b/microcosm_postgres/models.py
@@ -80,6 +80,10 @@ class PrimaryKeyMixin:
     def updated_timestamp(self):
         return (self.updated_at.replace(tzinfo=None) - EPOCH).total_seconds()
 
+    @property
+    def sort_key(self):
+        return self.created_at.asc()
+
 
 class UnixTimestampPrimaryKeyMixin:
     """

--- a/microcosm_postgres/store.py
+++ b/microcosm_postgres/store.py
@@ -221,7 +221,7 @@ class Store:
 
         """
         if hasattr(self.model_class, "sort_by"):
-            return query.order_by(self.model_class.sort_by)
+            return query.order_by(self.model_class.sort_by())
 
         return query
 

--- a/microcosm_postgres/store.py
+++ b/microcosm_postgres/store.py
@@ -220,6 +220,9 @@ class Store:
         By default, is a noop.
 
         """
+        if hasattr(self.model_class, "sort_by"):
+            return query.order_by(self.model_class.sort_by)
+
         return query
 
     def _filter(self, query, **kwargs):


### PR DESCRIPTION
Within our existing search endpoints, we require client users to manually over-ride Search.order_by in order to have endpoints return sorted objects.  Without overriding this key there is no guarantee that postgres will return results in a consistent order:

https://www.postgresql.org/docs/current/queries-order.html

This means that you can refresh the same offset & limit multiple times and get different objects returned, which breaks our pagination protocol.

This PR introduces a simple default as part of the `PrimaryKeyMixin`, which will sort objects by ascending created_at dates.  This guarantees that new objects coming into the database during search iteration will appear at the end of the list and therefore not affect the current pagination.  If client callers want another sorting schema, they can either override the store (current behavior) or add a new sorting configuration to the sort_by method within the model.