### PR TITLE
Parse only known arguments in `createall`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ jobs:
           name: pull and run database - postgres
           command: |
             docker pull postgres
-            docker run -d --name microcosm_postgres_db -e POSTGRES_DB=example_test_db -e POSTGRES_USER=example postgres
+            docker run -d --name microcosm_postgres_db -e POSTGRES_HOST_AUTH_METHOD=trust -e POSTGRES_DB=example_test_db -e POSTGRES_USER=example postgres
       - run:
           name: Test code
           command: |

--- a/microcosm_postgres/createall.py
+++ b/microcosm_postgres/createall.py
@@ -10,7 +10,9 @@ from microcosm_postgres.operations import create_all, drop_all
 def parse_args(graph):
     parser = ArgumentParser()
     parser.add_argument("--drop", "-D", action="store_true")
-    return parser.parse_args()
+    # Allow services to set custom arguments for `createall`
+    arguments, _ = parser.parse_known_args()
+    return arguments
 
 
 def main(graph):


### PR DESCRIPTION
**Why?**
Services using `createall` may want to have custom behavior, depending on arguments that they will parse but that will be unrecognized here.

**What?**
Only parse know arguments in `createall`.