### PR TITLE
Explicitly enable `restore_load_context` for encrypted entities

### DIFF
--- a/microcosm_postgres/encryption/models.py
+++ b/microcosm_postgres/encryption/models.py
@@ -164,7 +164,7 @@ class EncryptableMixin:
             # Hence the `__encryptor__` hack above...
             if contains(cls, name, func):
                 remove(cls, name, func)
-            listen(cls, name, func)
+            listen(cls, name, func, restore_load_context=True)
 
 
 class EncryptedMixin:

--- a/microcosm_postgres/tests/encryption/fixtures/sub_encryptable.py
+++ b/microcosm_postgres/tests/encryption/fixtures/sub_encryptable.py
@@ -1,0 +1,101 @@
+from typing import Sequence, Tuple
+
+from microcosm.api import binding
+from sqlalchemy import (
+    CheckConstraint,
+    Column,
+    ForeignKey,
+    String,
+)
+from sqlalchemy.orm import relationship
+from sqlalchemy_utils import UUIDType
+
+from microcosm_postgres.encryption.models import EncryptableMixin, EncryptedMixin
+from microcosm_postgres.encryption.store import EncryptableStore
+from microcosm_postgres.models import EntityMixin, Model
+from microcosm_postgres.store import Store
+
+
+class Parent(EntityMixin, Model):
+    __tablename__ = "parent"
+
+    name = Column(String)
+
+    __mapper_args__ = {
+        "polymorphic_identity": "parent",
+        "polymorphic_on": name,
+    }
+
+
+class SubEncrypted(EntityMixin, EncryptedMixin, Model):
+    __tablename__ = "sub_encrypted"
+
+
+class SubEncryptable(Parent, EncryptableMixin):
+    """
+    A model for conditionally-encrypted plaintext.
+
+    """
+    __tablename__ = "sub_encryptable"
+
+    id = Column(UUIDType, ForeignKey("parent.id"), primary_key=True)
+    # key used for encryption context
+    key = Column(String, nullable=False)
+    # value is not encrypted
+    value = Column(String, nullable=True)
+    # foreign key to encrypted data
+    sub_encrypted_id = Column(UUIDType, ForeignKey("sub_encrypted.id"), nullable=True)
+    # load and update encrypted relationship automatically
+    sub_encrypted = relationship(
+        SubEncrypted,
+        lazy="joined",
+    )
+
+    __mapper_args__ = {
+        "polymorphic_identity": "sub",
+    }
+
+    __table_args__ = (
+        CheckConstraint(
+            name="value_or_encrypted_is_not_null",
+            sqltext="value IS NOT NULL OR sub_encrypted_id IS NOT NULL",
+        ),
+        CheckConstraint(
+            name="value_or_encrypted_is_null",
+            sqltext="value IS NULL OR sub_encrypted_id IS NULL",
+        ),
+    )
+    __encrypted_identifier__ = "sub_encrypted_id"
+
+    @property
+    def ciphertext(self) -> Tuple[bytes, Sequence[str]]:
+        return (self.sub_encrypted.ciphertext, self.sub_encrypted.key_ids)
+
+    @ciphertext.setter
+    def ciphertext(self, value: Tuple[bytes, Sequence[str]]) -> None:
+        ciphertext, key_ids = value
+        self.sub_encrypted = SubEncrypted(
+            ciphertext=ciphertext,
+            key_ids=key_ids,
+        )
+
+
+@binding("sub_encrypted_store")
+class SubEncryptedStore(Store):
+
+    def __init__(self, graph):
+        super().__init__(graph, SubEncrypted)
+
+
+@binding("sub_encryptable_store")
+class SubEncryptableModelStore(EncryptableStore):
+
+    def __init__(self, graph):
+        super().__init__(graph, SubEncryptable, graph.sub_encrypted_store)
+
+
+@binding("parent_store")
+class ParentStore(Store):
+
+    def __init__(self, graph):
+        super().__init__(graph, Parent)

--- a/microcosm_postgres/tests/factories/test_engine.py
+++ b/microcosm_postgres/tests/factories/test_engine.py
@@ -2,14 +2,6 @@
 Factory tests.
 
 """
-from hamcrest import (
-    assert_that,
-    ends_with,
-    equal_to,
-    instance_of,
-    is_,
-    starts_with,
-)
 from microcosm.api import create_object_graph
 from sqlalchemy.engine.base import Engine
 
@@ -22,20 +14,13 @@ def test_configure_engine():
     graph = create_object_graph(name="example", testing=True)
     engine = graph.postgres
 
-    assert_that(engine, is_(instance_of(Engine)))
+    assert isinstance(engine, Engine)
 
     # engine has expected configuration
-    assert_that(
-        str(engine.url),
-        starts_with("postgresql://example:@"),
-    )
-
-    assert_that(
-        str(engine.url),
-        ends_with(":5432/example_test_db"),
-    )
+    assert str(engine.url).startswith("postgresql://example:@")
+    assert str(engine.url).endswith(":5432/example_test_db")
 
     # engine supports connections
     with engine.connect() as connection:
         row = connection.execute("SELECT 1;").fetchone()
-        assert_that(row[0], is_(equal_to(1)))
+        assert row[0] == 1


### PR DESCRIPTION
This directive informs SQLA that it should restore the original context
(i.e. runid) for a for a given entity, instead of treating it as a
different context.

This prevents a warning from being erroneously emitted in the following
scenario:
* Unencrypted Parent class
* Encrypted polymorphic subclass of Parent

When the parent class is loaded, SQLA doesn't appear to take into
account any relationships of the relevant subclasses, meaning that it
needs to emit extra selects to fetch those attached entities once the
subclass has been fully loaded. Those additional queries then change
the context, causing SQLA to warn about it.

For more context:
https://github.com/zzzeek/sqlalchemy/commit/10b7937bb9994c365436af5e0c1931b2b07d12b1
https://github.com/sqlalchemy/sqlalchemy/issues/4094