### PR TITLE
Prepare library for aws-encryption-sdk 2.1.x migration

### DIFF
--- a/microcosm_postgres/encryption/encryptor.py
+++ b/microcosm_postgres/encryption/encryptor.py
@@ -18,8 +18,13 @@ class SingleTenantEncryptor:
     A single tenant encryptor.
 
     """
-    def __init__(self, materials_manager: CryptoMaterialsManager):
-        self.materials_manager = materials_manager
+    def __init__(
+        self,
+        encrypting_materials_manager: CryptoMaterialsManager,
+        decrypting_materials_manager: CryptoMaterialsManager,
+    ):
+        self.encrypting_materials_manager = encrypting_materials_manager
+        self.decrypting_materials_manager = decrypting_materials_manager
         self.encryption_client = EncryptionSDKClient(
             commitment_policy=CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT,
         )
@@ -42,9 +47,9 @@ class SingleTenantEncryptor:
             microcosm=encryption_context_key,
         )
 
-        cyphertext, header = self.encryption_client.encrypt(
+        ciphertext, header = self.encryption_client.encrypt(
             source=plaintext,
-            materials_manager=self.materials_manager,
+            materials_manager=self.encrypting_materials_manager,
             encryption_context=encryption_context,
         )
 
@@ -52,12 +57,12 @@ class SingleTenantEncryptor:
             self.unpack_key_id(encrypted_data_key.key_provider)
             for encrypted_data_key in header.encrypted_data_keys
         ]
-        return cyphertext, key_ids
+        return ciphertext, key_ids
 
     def decrypt(self, encryption_context_key: str, ciphertext: bytes) -> str:
         plaintext, header = self.encryption_client.decrypt(
             source=ciphertext,
-            materials_manager=self.materials_manager,
+            materials_manager=self.decrypting_materials_manager,
         )
         return plaintext.decode("utf-8")
 

--- a/microcosm_postgres/encryption/registry.py
+++ b/microcosm_postgres/encryption/registry.py
@@ -2,7 +2,7 @@
 A registry for context keys and their master key ids.
 
 """
-from typing import Mapping, Sequence
+from typing import Mapping, Sequence, Union
 
 from microcosm.api import defaults
 from microcosm.config.types import comma_separated_list
@@ -11,23 +11,32 @@ from microcosm_logging.decorators import logger
 
 from microcosm_postgres.encryption.encryptor import MultiTenantEncryptor, SingleTenantEncryptor
 from microcosm_postgres.encryption.providers import (
-    configure_key_provider,
+    configure_decrypting_key_provider,
+    configure_encrypting_key_provider,
     configure_materials_manager,
 )
 
 
 def parse_config(context_keys: Sequence[str],
-                 key_ids: Sequence[str]) -> Mapping[str, Sequence[str]]:
+                 key_ids: Sequence[Union[str, Sequence[str]]],
+                 account_ids: Sequence[Union[str, Sequence[str]]],
+                 partitions: Sequence[Union[str, Sequence[str]]]) -> Mapping[str, Mapping[str, Sequence[str]]]:
     return {
         # NB: split key id on non-comma to avoid confusion with config parsing
-        context_key: key_id.split(";") if isinstance(key_id, str) else key_id
-        for context_key, key_id in zip(context_keys, key_ids)
+        context_key: {
+            "key_ids": key_id.split(";") if isinstance(key_id, str) else key_id,
+            "account_ids": account_id.split(";") if isinstance(account_id, str) else account_id,
+            "partition": partition,
+        }
+        for context_key, key_id, account_id, partition in zip(context_keys, key_ids, account_ids, partitions)
     }
 
 
 @defaults(
     context_keys=typed(comma_separated_list, default_value=""),
     key_ids=typed(comma_separated_list, default_value=""),
+    partitions=typed(comma_separated_list, default_value=""),
+    account_ids=typed(comma_separated_list, default_value=""),
 )
 @logger
 class MultiTenantKeyRegistry:
@@ -37,8 +46,10 @@ class MultiTenantKeyRegistry:
     """
     def __init__(self, graph):
         self.keys = parse_config(
+            account_ids=graph.config.multi_tenant_key_registry.account_ids,
             context_keys=graph.config.multi_tenant_key_registry.context_keys,
             key_ids=graph.config.multi_tenant_key_registry.key_ids,
+            partitions=graph.config.multi_tenant_key_registry.partitions,
         )
 
         for context_key, key_ids in self.keys.items():
@@ -54,11 +65,20 @@ class MultiTenantKeyRegistry:
         return MultiTenantEncryptor(
             encryptors={
                 context_key: SingleTenantEncryptor(
-                    materials_manager=configure_materials_manager(
+                    encrypting_materials_manager=configure_materials_manager(
                         graph,
-                        key_provider=configure_key_provider(graph, key_ids),
-                    )
+                        key_provider=configure_encrypting_key_provider(graph, context_data["key_ids"]),
+                    ),
+                    decrypting_materials_manager=configure_materials_manager(
+                        graph,
+                        key_provider=configure_decrypting_key_provider(
+                            graph,
+                            context_data["account_ids"],
+                            context_data["partition"],
+                            context_data["key_ids"],
+                        ),
+                    ),
                 )
-                for context_key, key_ids in self.keys.items()
+                for context_key, context_data in self.keys.items()
             },
         )

--- a/microcosm_postgres/tests/encryption/test_encryptor.py
+++ b/microcosm_postgres/tests/encryption/test_encryptor.py
@@ -39,6 +39,12 @@ def test_cycle_single_tenant():
             key_ids=[
                 ["key1", "key2"],
             ],
+            partitions=[
+                "aws",
+            ],
+            account_ids=[
+                "12345",
+            ]
         ),
     )
     graph = create_object_graph(
@@ -65,6 +71,14 @@ def test_cycle_multi_tenant():
             key_ids=[
                 ["foo1", "foo2"],
                 ["bar1", "bar2"],
+            ],
+            partitions=[
+                "aws",
+                "aws-cn",
+            ],
+            account_ids=[
+                ["12345", "67890"],
+                ["23456", "78901"],
             ],
         ),
     )
@@ -100,6 +114,12 @@ def test_cycle_cache():
             key_ids=[
                 ["key1", "key2"],
             ],
+            partitions=[
+                "aws",
+            ],
+            account_ids=[
+                ["12345"],
+            ]
         ),
     )
     graph = create_object_graph(
@@ -109,7 +129,7 @@ def test_cycle_cache():
         loader=loader,
     )
     encryptor = graph.multi_tenant_encryptor.encryptors["default"]
-    master_key_provider = encryptor.materials_manager.master_key_provider
+    master_key_provider = encryptor.decrypting_materials_manager.master_key_provider
     decrypt_data_key = master_key_provider.decrypt_data_key
 
     with patch.object(master_key_provider, "decrypt_data_key") as mocked_decrypt_data_key:

--- a/microcosm_postgres/tests/encryption/test_encryptor.py
+++ b/microcosm_postgres/tests/encryption/test_encryptor.py
@@ -14,7 +14,7 @@ import microcosm_postgres.encryption.factories  # noqa: F401
 
 
 try:
-    from aws_encryption_sdk import decrypt, encrypt  # noqa: F401
+    from aws_encryption_sdk import EncryptionSDKClient  # noqa: F401
 except ImportError:
     raise SkipTest
 

--- a/microcosm_postgres/tests/encryption/test_models.py
+++ b/microcosm_postgres/tests/encryption/test_models.py
@@ -36,6 +36,12 @@ class TestEncryptable:
                     key_ids=[
                         "key_id",
                     ],
+                    partitions=[
+                        "aws",
+                    ],
+                    account_ids=[
+                        "12345",
+                    ]
                 ),
             ),
             load_from_environ,

--- a/microcosm_postgres/tests/encryption/test_registry.py
+++ b/microcosm_postgres/tests/encryption/test_registry.py
@@ -10,7 +10,7 @@ from microcosm_postgres.encryption.registry import parse_config
 
 
 try:
-    from aws_encryption_sdk import decrypt, encrypt  # noqa: F401
+    from aws_encryption_sdk import EncryptionSDKClient  # noqa: F401
 except ImportError:
     raise SkipTest
 

--- a/microcosm_postgres/tests/encryption/test_registry.py
+++ b/microcosm_postgres/tests/encryption/test_registry.py
@@ -4,7 +4,7 @@ Test registry configuration.
 """
 from unittest import SkipTest
 
-from hamcrest import assert_that, equal_to, is_
+from hamcrest import assert_that, has_entries
 
 from microcosm_postgres.encryption.registry import parse_config
 
@@ -20,20 +20,37 @@ def test_parse_config_simple():
         parse_config(
             context_keys=["foo"],
             key_ids=["bar"],
+            account_ids=["12345"],
+            partitions=["aws"],
         ),
-        is_(equal_to(dict(
-            foo=["bar"],
-        ))),
+        has_entries(
+            foo=has_entries(
+                key_ids=["bar"],
+                account_ids=["12345"],
+                partition="aws",
+            ),
+        ),
     )
 
 
 def test_parse_config_key_ids():
     assert_that(
         parse_config(
-            context_keys=["foo"],
-            key_ids=["bar;baz"],
+            context_keys=["foo", "quux"],
+            key_ids=["bar;baz", "quuz;corge"],
+            partitions=["aws", "aws-cn"],
+            account_ids=["12345;67890", "23456;78901"],
         ),
-        is_(equal_to(dict(
-            foo=["bar", "baz"],
-        ))),
+        has_entries(
+            foo=has_entries(
+                key_ids=["bar", "baz"],
+                partition="aws",
+                account_ids=["12345", "67890"],
+            ),
+            quux=has_entries(
+                key_ids=["quuz", "corge"],
+                partition="aws-cn",
+                account_ids=["23456", "78901"],
+            ),
+        ),
     )


### PR DESCRIPTION
Updates and replaces encryption to account for changes/deprecations relating to aws-encryption-sdk 2.1.x

## Replaces deprecated usage of encrypt/decrypt with the new dedicated EncryptionSDKClient.

The main driver change here appears to have been with "key commitment" (see ref).
The recommended change here is to use the client explicitly configured to be
backwards compatible.
 
## Replace usage of KMSMasterKeyProvider

This class was explicitly deprecated and removed in 2.x, to be replaced
with two different kinds of KeyProviders:
* StrictAwsKmsMasterKeyProvider
* DiscoveryAwsKmsMasterKeyProvider

The strict provider will continue to work as the previous provider had
done, encrypting new rows with the explicitly-provided keys.

Decryption, however, will use the discovery provider to decrypt values
in order to keep working with older accounts and values not explicitly
listed. This may change in the future, as it may be preferable to use a
strict provider on both ends. This will require, however, all rows to be
vetted to ensure all keys are accounted for.

References:
https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/migration-guide.html
https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/migration.html
https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/concepts.html#key-commitment
https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/migrate-mkps-v2.html
