### PR TITLE
Unpin aws-encryption-sdk

### DIFF
--- a/microcosm_postgres/tests/factories/test_engine.py
+++ b/microcosm_postgres/tests/factories/test_engine.py
@@ -2,6 +2,8 @@
 Factory tests.
 
 """
+from os import environ
+
 from hamcrest import (
     assert_that,
     ends_with,
@@ -24,7 +26,10 @@ def test_configure_engine():
     assert isinstance(engine, Engine)
 
     # engine has expected configuration
-    assert_that(str(engine.url), starts_with("postgresql://example:@"))
+    user = environ.get("EXAMPLE__POSTGRES__USER", "example")
+    password = environ.get("EXAMPLE__POSTGRES__PASSWORD", "")
+
+    assert_that(str(engine.url), starts_with(f"postgresql://{user}:{password}@"))
     assert_that(str(engine.url), ends_with(":5432/example_test_db"))
 
     # engine supports connections

--- a/microcosm_postgres/tests/factories/test_engine.py
+++ b/microcosm_postgres/tests/factories/test_engine.py
@@ -24,7 +24,7 @@ def test_configure_engine():
     assert isinstance(engine, Engine)
 
     # engine has expected configuration
-    assert_that(str(engine.url), starts_with("postgresql://example:test@"))
+    assert_that(str(engine.url), starts_with("postgresql://example:@"))
     assert_that(str(engine.url), ends_with(":5432/example_test_db"))
 
     # engine supports connections

--- a/microcosm_postgres/tests/temporary/test_temporary.py
+++ b/microcosm_postgres/tests/temporary/test_temporary.py
@@ -83,7 +83,7 @@ class TestTransient:
                             index_elements=["id"],
                             set_=dict(
                                 type=CompanyType.public,
-                                updated_at=datetime.now(),
+                                updated_at=datetime.utcnow(),
                             ),
                         ),
                         is_(equal_to(3)),

--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,7 @@ setup(
     ],
     extras_require={
         "metrics": "microcosm-metrics>=2.5.0",
-        # 09-25-2020: pin aws encryption b/c of breaking API changes
-        "encryption": "aws-encryption-sdk==1.7.1",
+        "encryption": "aws-encryption-sdk>=2.0.0",
     },
     entry_points={
         "microcosm.factories": [


### PR DESCRIPTION
- fix unit-test baseline - two were failing
- unpin aws-encryption-sdk and updated relevant code paths

*NOTE*: before making a release with these changes, services using this library (which are most of our stateful services) require a config update, see [this ansible-deploy PR](https://github.com/globality-corp/ansible-deploy/pull/3467) for example of required changes. we have yet to test these.