### PR TITLE
bump minimum version requirements of sqlalchemy and sqlalchemy-utils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,8 @@ setup(
         "microcosm-logging>=1.5.0",
         "psycopg2-binary>=2.7.5",
         "pytz>=2018.5",
-        "SQLAlchemy>=1.2.11",
-        "SQLAlchemy-Utils>=0.33.3",
+        "SQLAlchemy>=1.4.10",
+        "SQLAlchemy-Utils>=0.37.0",
     ],
     setup_requires=[
         "nose>=1.3.6",


### PR DESCRIPTION
This is to ensure compatability with latest 1.4.x in preparation for sqlalchemy 2.x release and related bugfixes affecting microcosm-eventsource.

See also:
https://github.com/sqlalchemy/sqlalchemy/issues/6256
https://github.com/globality-corp/microcosm-eventsource/pull/74
https://github.com/globality-corp/microcosm-eventsource/pull/75