### PR TITLE
Release 2.2.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.1.0
+current_version = 2.2.0
 commit = False
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 
 project = "microcosm-postgres"
-version = "2.1.0"
+version = "2.2.0"
 
 setup(
     name=project,

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,8 @@ setup(
         "microcosm-logging>=1.5.0",
         "psycopg2-binary>=2.7.5",
         "pytz>=2018.5",
-        "SQLAlchemy>=1.2.11",
-        "SQLAlchemy-Utils>=0.33.3",
+        "SQLAlchemy>=1.4.10",
+        "SQLAlchemy-Utils>=0.37.0",
     ],
     setup_requires=[
         "nose>=1.3.6",


### PR DESCRIPTION
Mainly, SQLALchemy 1.4.x support.

- SQLAlchemy and SQLAlchemy-utils dependencies updated to latest to incorporate compatability with 1.4.x and a recent bugfix affecting microcosm-eventsource