### PR TITLE
Bump to 3.1.0 to make sure upgrades are required

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.0.0
+current_version = 3.1.0
 commit = False
 tag = False
 

--- a/README.md
+++ b/README.md
@@ -112,4 +112,4 @@ The official [sqlalchemy 2 migration guide](https://docs.sqlalchemy.org/en/20/ch
 
 Additionally, follow https://docs.sqlalchemy.org/en/20/changelog/whatsnew_20.html#orm-declarative-models to update your models to use the new declarative styles.
 
-Version 3.x also introduced auto retry on disconnect, which is enabled by default. If you want to disable it, set `config.postgres.engine_retries` to `0`.
+Version 3.1.x also introduced auto retry on disconnect, which is enabled by default. If you want to disable it, set `config.postgres.engine_retries` to `0`.

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 
 project = "microcosm-postgres"
-version = "3.0.0"
+version = "3.1.0"
 
 setup(
     name=project,


### PR DESCRIPTION
* We already have 3.0.0 released we need 3.1.0 in order to make sure it will require change.