### PR TITLE
Adding beacon implementation to encryptor hybrid

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.6.5
+current_version = 3.6.0
 commit = False
 tag = False
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.5.5
+current_version = 3.6.5
 commit = False
 tag = False
 

--- a/microcosm_postgres/encryption/v2/column.py
+++ b/microcosm_postgres/encryption/v2/column.py
@@ -22,20 +22,13 @@ NOT_SET = object()
 
 def beaconise(word):
     """
-    No op for now
-
-    :param word:
-    :return:
+    Mock implementation of beaconisation.
     """
     return f"{word} beaconised"
 
 
 class BeaconComparator(Comparator[str]):
     def __init__(self, name, beacon_name: Any = None):
-
-
-
-        # breakpoint()
         if isinstance(name, str):
             self.name = beaconise(name)
         elif isinstance(name, BeaconComparator):

--- a/microcosm_postgres/encryption/v2/column.py
+++ b/microcosm_postgres/encryption/v2/column.py
@@ -6,8 +6,8 @@ from typing import (
     overload,
 )
 
-from sqlalchemy import LargeBinary
-from sqlalchemy.ext.hybrid import hybrid_property
+from sqlalchemy import LargeBinary, String, ColumnElement
+from sqlalchemy.ext.hybrid import hybrid_property, Comparator
 from sqlalchemy.orm import Mapped, mapped_column
 
 from .encoders import Encoder
@@ -18,6 +18,51 @@ T = TypeVar("T")
 
 
 NOT_SET = object()
+
+
+def beaconise(word):
+    """
+    No op for now
+
+    :param word:
+    :return:
+    """
+    return f"{word} beaconised"
+
+
+class BeaconComparator(Comparator[str]):
+    def __init__(self, name, beacon_name: Any = None):
+
+
+
+        # breakpoint()
+        if isinstance(name, str):
+            self.name = beaconise(name)
+        elif isinstance(name, BeaconComparator):
+            self.name = name.name
+        else:
+            self.name = name
+
+        # Note that we only store beacon name when we are instantiating as part of
+        # the sqlalchemy model setup
+        self.beacon_name = beacon_name
+
+    def operate(self, op, other, **kwargs):
+        if not isinstance(other, BeaconComparator):
+            other = BeaconComparator(other)
+        return op(self.name, other.name, **kwargs)
+
+    def __clause_element__(self):
+        return self.beacon_name
+
+    def __str__(self):
+        return self.name
+
+    def __eq__(self, other: Any) -> ColumnElement[bool]:  # type: ignore[override]  # noqa: E501
+        # Here we would beaconise the "other" value
+        return self.__clause_element__() == beaconise(other)
+
+    key = 'name'
 
 
 class encryption(hybrid_property[T], Generic[T]):
@@ -59,6 +104,7 @@ class encryption(hybrid_property[T], Generic[T]):
         self.encoder = encoder
         self.column_type = encoder.sa_type if column_type is NOT_SET else column_type
 
+        beacon_field = f"{key}_beacon"
         encrypted_field = f"{key}_encrypted"
         unencrypted_field = f"{key}_unencrypted"
 
@@ -75,15 +121,19 @@ class encryption(hybrid_property[T], Generic[T]):
             if encrypted is None:
                 setattr(self, unencrypted_field, value)
                 setattr(self, encrypted_field, None)
+                setattr(self, beacon_field, None)
                 return
+
+            if hasattr(self, beacon_field):
+                setattr(self, beacon_field, beaconise(value))
 
             setattr(self, encrypted_field, encrypted)
             setattr(self, unencrypted_field, None)
 
-        def _prop_expression(cls):
-            return getattr(cls, unencrypted_field)
+        def _prop_comparator(cls):
+            return BeaconComparator(getattr(cls, unencrypted_field), getattr(cls, beacon_field))
 
-        super().__init__(_prop, _prop_setter, expr=_prop_expression)
+        super().__init__(_prop, _prop_setter, custom_comparator=_prop_comparator)
 
     def encrypted(self) -> Mapped[bytes | None]:
         if self.default is NOT_SET:
@@ -121,3 +171,7 @@ class encryption(hybrid_property[T], Generic[T]):
             ),
             **kwargs,
         )
+
+    def beacon(self, **kwargs: Any):
+        # TODO - assume all encrypted fields need to use beacons
+        return mapped_column(String, nullable=True, **kwargs)

--- a/microcosm_postgres/encryption/v2/column.py
+++ b/microcosm_postgres/encryption/v2/column.py
@@ -209,5 +209,5 @@ class encryption(hybrid_property[T], Generic[T]):
             **kwargs,
         )
 
-    def beacon(self, **kwargs: Any):
+    def beacon(self, **kwargs: Any) -> Mapped[str | None]:
         return mapped_column(String, nullable=True, **kwargs)

--- a/microcosm_postgres/encryption/v2/column.py
+++ b/microcosm_postgres/encryption/v2/column.py
@@ -61,6 +61,10 @@ class BeaconComparator(Comparator[str]):
     key = 'beacon'
 
 
+class BeaconNotDefinedError(Exception):
+    pass
+
+
 class encryption(hybrid_property[T], Generic[T]):
     @overload
     def __init__(
@@ -117,7 +121,6 @@ class encryption(hybrid_property[T], Generic[T]):
             if encrypted is None:
                 setattr(self, unencrypted_field, value)
                 setattr(self, encrypted_field, None)
-                setattr(self, beacon_field, None)
                 return
 
             if hasattr(self, beacon_field):

--- a/microcosm_postgres/encryption/v2/column.py
+++ b/microcosm_postgres/encryption/v2/column.py
@@ -6,8 +6,8 @@ from typing import (
     overload,
 )
 
-from sqlalchemy import LargeBinary, String, ColumnElement
-from sqlalchemy.ext.hybrid import hybrid_property, Comparator
+from sqlalchemy import ColumnElement, LargeBinary, String
+from sqlalchemy.ext.hybrid import Comparator, hybrid_property
 from sqlalchemy.orm import Mapped, mapped_column
 
 from .encoders import Encoder

--- a/microcosm_postgres/encryption/v2/column.py
+++ b/microcosm_postgres/encryption/v2/column.py
@@ -38,7 +38,7 @@ class BeaconComparator(Comparator):
         self.beacon_fn = beacon_fn
         self.val = val
 
-    def operate(self, op, other: Any = NOT_SET, **kwargs: Any) -> ColumnElement[Any]:  # type: ignore[override]  # noqa: E501
+    def operate(self, op: Callable, other: Any = NOT_SET, **kwargs: Any) -> ColumnElement[Any]:  # type: ignore[override]  # noqa: E501
         # This first condition might happen when we are doing an order by ACS / DESC
         if other is NOT_SET:
             return op(self.beacon_val)
@@ -48,6 +48,7 @@ class BeaconComparator(Comparator):
             # e.g [1,2,3] -> [beacon(1), beacon(2), beacon(3)]
             return op(self.beacon_val, [self._beaconise(v) for v in other], **kwargs)
         elif not isinstance(other, BeaconComparator):
+            breakpoint()
             other = BeaconComparator(other)
         return op(self.val, other.val, **kwargs)
 

--- a/microcosm_postgres/encryption/v2/encryptors.py
+++ b/microcosm_postgres/encryption/v2/encryptors.py
@@ -31,6 +31,10 @@ class Encryptor(Protocol):
         """Decrypt a value key identified from the ciphertext."""
         ...
 
+    def beacon(self, value: str) -> str:
+        """Hash value using the beacon key."""
+        ...
+
 
 class PlainTextEncryptor(Encryptor):
     def should_encrypt(self) -> bool:
@@ -50,6 +54,9 @@ class AwsKmsEncryptor(Encryptor):
     _encryptor_context: ContextVar[EncryptorContext] = ContextVar("_encryptor_context")
 
     class EncryptorNotBound(Exception):
+        status_code = 403
+
+    class BeaconKeyNotSet(Exception):
         status_code = 403
 
     @property
@@ -131,3 +138,14 @@ class AwsKmsEncryptor(Encryptor):
 
         context, encryptor = self.encryptor_context
         return encryptor.decrypt(context, value)
+
+    def beacon(self, value: str) -> str:
+        if self.encryptor_context is None:
+            raise self.EncryptorNotBound()
+
+        _, encryptor = self.encryptor_context
+        beacon = encryptor.beacon(value)
+        if beacon is None:
+            raise self.BeaconKeyNotSet()
+
+        return beacon

--- a/microcosm_postgres/tests/test_employee_store_with_encryption.py
+++ b/microcosm_postgres/tests/test_employee_store_with_encryption.py
@@ -38,7 +38,6 @@ class EmployeeStore(Store):
         return self.search(Employee.name == name)
 
     def _order_by(self, query, **kwargs):
-        # What if the order by order is on the name_encrypted column?
         return query.order_by(Employee.id.asc())
 
     def _filter(self, query, **kwargs):
@@ -138,6 +137,14 @@ def session(sessionmaker: SessionMaker) -> Iterator[Session]:
     finally:
         session.rollback()
         session.close()
+
+
+def test_beacon_value_generation():
+    """
+    Test that checks that the beacon value is generated as expected
+
+    """
+    pass
 
 
 def test_encrypt_and_search_using_beacon(

--- a/microcosm_postgres/tests/test_employee_store_with_encryption.py
+++ b/microcosm_postgres/tests/test_employee_store_with_encryption.py
@@ -179,7 +179,7 @@ def test_encrypt_no_beacon_used(
         assert employee.salary_unencrypted is None
         assert employee.salary_encrypted is not None
         with pytest.raises(AttributeError):
-            assert employee.salary_beacon is None
+            assert employee.salary_beacon is None  # type: ignore[attr-defined]
 
         assert employee.name == "foo"
         assert employee.salary == 100

--- a/microcosm_postgres/tests/test_employee_store_with_encryption.py
+++ b/microcosm_postgres/tests/test_employee_store_with_encryption.py
@@ -210,6 +210,18 @@ def test_encrypt_and_search_using_beacon_with_no_beacon_key():
                 session.commit()
 
 
+def test_encryptor_not_bound_when_beacon_used_without_context(
+    session: Session,
+    single_tenant_encryptor: SingleTenantEncryptor,
+    graph: ObjectGraph,
+) -> None:
+    with pytest.raises(AwsKmsEncryptor.EncryptorNotBound):
+        session.add(Employee(name="foo"))
+
+        query = session.query(Employee).filter(Employee.name == "foo")
+        query.all()
+
+
 def test_encrypt_no_beacon_used(
     session: Session,
     single_tenant_encryptor: SingleTenantEncryptor,

--- a/microcosm_postgres/tests/test_employee_store_with_encryption.py
+++ b/microcosm_postgres/tests/test_employee_store_with_encryption.py
@@ -21,7 +21,7 @@ from sqlalchemy.orm import Session, mapped_column, sessionmaker as SessionMaker
 
 from microcosm_postgres.context import SessionContext
 from microcosm_postgres.encryption.encryptor import MultiTenantEncryptor, SingleTenantEncryptor
-from microcosm_postgres.encryption.v2.column import encryption
+from microcosm_postgres.encryption.v2.column import encryption, BeaconNotDefinedError
 from microcosm_postgres.encryption.v2.encoders import ArrayEncoder, Nullable, StringEncoder, IntEncoder
 from microcosm_postgres.encryption.v2.encryptors import AwsKmsEncryptor
 from microcosm_postgres.models import Model
@@ -61,8 +61,8 @@ class Employee(Model):
     name_unencrypted = name.unencrypted(index=True)
     name_beacon = name.beacon()
 
-    # Salary does not require beacon value for search
-    salary = encryption("salary", AwsKmsEncryptor(), IntEncoder())
+    # Salary does not require beacon value
+    salary = encryption("salary", AwsKmsEncryptor(), IntEncoder(), opt_out_beacon=True)
     salary_encrypted = salary.encrypted()
     salary_unencrypted = salary.unencrypted()
 
@@ -229,9 +229,6 @@ def test_searching_on_encrypted_field_with_no_beacon(
     """
     This test checks that it doesn't break if you try to search for a field
     which is encrypted but with no beacon field defined.
-
-    We post a warning log message to let the engineer know that
-    they might want to consider adding a beacon to actually enable the search?
 
     """
 

--- a/microcosm_postgres/tests/test_employee_store_with_encryption.py
+++ b/microcosm_postgres/tests/test_employee_store_with_encryption.py
@@ -62,7 +62,7 @@ class Employee(Model):
     name_beacon = name.beacon()
 
     # Salary does not require beacon value
-    salary = encryption("salary", AwsKmsEncryptor(), IntEncoder(), opt_out_beacon=True)
+    salary = encryption("salary", AwsKmsEncryptor(), IntEncoder())
     salary_encrypted = salary.encrypted()
     salary_unencrypted = salary.unencrypted()
 

--- a/microcosm_postgres/tests/test_employee_store_with_encryption.py
+++ b/microcosm_postgres/tests/test_employee_store_with_encryption.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import re
-
-from sqlalchemy import select
 from typing import TYPE_CHECKING, ClassVar, Iterator
 from uuid import uuid4
 
@@ -16,13 +14,13 @@ from microcosm.api import (
 from microcosm.decorators import binding
 from microcosm.object_graph import ObjectGraph
 from pytest import fixture
-from sqlalchemy import UUID, Table
+from sqlalchemy import UUID, Table, select
 from sqlalchemy.orm import Session, mapped_column, sessionmaker as SessionMaker
 
 from microcosm_postgres.context import SessionContext
 from microcosm_postgres.encryption.encryptor import MultiTenantEncryptor, SingleTenantEncryptor
 from microcosm_postgres.encryption.v2.column import encryption
-from microcosm_postgres.encryption.v2.encoders import StringEncoder, IntEncoder
+from microcosm_postgres.encryption.v2.encoders import IntEncoder, StringEncoder
 from microcosm_postgres.encryption.v2.encryptors import AwsKmsEncryptor
 from microcosm_postgres.models import Model
 from microcosm_postgres.store import Store

--- a/microcosm_postgres/tests/test_employee_store_with_encryption.py
+++ b/microcosm_postgres/tests/test_employee_store_with_encryption.py
@@ -21,8 +21,8 @@ from sqlalchemy.orm import Session, mapped_column, sessionmaker as SessionMaker
 
 from microcosm_postgres.context import SessionContext
 from microcosm_postgres.encryption.encryptor import MultiTenantEncryptor, SingleTenantEncryptor
-from microcosm_postgres.encryption.v2.column import encryption, BeaconNotDefinedError
-from microcosm_postgres.encryption.v2.encoders import ArrayEncoder, Nullable, StringEncoder, IntEncoder
+from microcosm_postgres.encryption.v2.column import encryption
+from microcosm_postgres.encryption.v2.encoders import StringEncoder, IntEncoder
 from microcosm_postgres.encryption.v2.encryptors import AwsKmsEncryptor
 from microcosm_postgres.models import Model
 from microcosm_postgres.store import Store
@@ -86,6 +86,9 @@ def config() -> dict:
             account_ids=[
                 "12345",
             ],
+            beacon_keys=[
+                "beacon_key",
+            ]
         ),
     )
 
@@ -237,7 +240,6 @@ def test_searching_on_encrypted_field_with_no_beacon(
         session.add(Employee(name="bar", salary=1000))
         session.commit()
 
-    # query = session.query(Employee).order_by(Employee.name.asc())
     query = select(Employee).filter(Employee.salary == 1000).order_by(Employee.name.asc())
     results = session.execute(query).scalars().all()
 

--- a/microcosm_postgres/tests/test_employee_store_with_encryption.py
+++ b/microcosm_postgres/tests/test_employee_store_with_encryption.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, ClassVar, Iterator
+from uuid import uuid4
+
+from microcosm.api import (
+    create_object_graph,
+    load_each,
+    load_from_dict,
+    load_from_environ,
+)
+from microcosm.decorators import binding
+from microcosm.object_graph import ObjectGraph
+from pytest import fixture
+from sqlalchemy import UUID, Table
+from sqlalchemy.orm import Session, mapped_column, sessionmaker as SessionMaker
+
+from microcosm_postgres.context import SessionContext
+from microcosm_postgres.encryption.encryptor import MultiTenantEncryptor, SingleTenantEncryptor
+from microcosm_postgres.encryption.v2.column import encryption
+from microcosm_postgres.encryption.v2.encoders import ArrayEncoder, Nullable, StringEncoder
+from microcosm_postgres.encryption.v2.encryptors import AwsKmsEncryptor
+from microcosm_postgres.models import Model
+from microcosm_postgres.store import Store
+
+
+@binding("employee_store_with_encryption")
+class EmployeeStore(Store):
+
+    def __init__(self, graph):
+        super().__init__(graph, Employee)
+
+    def search_by_name(self, name):
+        return self.search(Employee.name == name)
+
+    def _order_by(self, query, **kwargs):
+        # What if the order by order is on the name_encrypted column?
+        return query.order_by(Employee.id.asc())
+
+    def _filter(self, query, **kwargs):
+        name = kwargs.get("name")
+        if name is not None:
+            query = query.filter(Employee.name == name)
+        return super(EmployeeStore, self)._filter(query, **kwargs)
+
+
+class Employee(Model):
+    __tablename__ = "test_encryption_employee_v2"
+    if TYPE_CHECKING:
+        __table__: ClassVar[Table]
+
+    id = mapped_column(UUID, primary_key=True, default=uuid4)
+
+    name = encryption("name", AwsKmsEncryptor(), StringEncoder())
+    name_encrypted = name.encrypted()
+    name_unencrypted = name.unencrypted(index=True)
+    name_beacon = name.beacon()
+
+
+client_id = uuid4()
+
+
+@fixture(scope="module")
+def config() -> dict:
+    return dict(
+        multi_tenant_key_registry=dict(
+            context_keys=[
+                str(client_id),
+            ],
+            key_ids=[
+                "key_id",
+            ],
+            partitions=[
+                "aws",
+            ],
+            account_ids=[
+                "12345",
+            ],
+        ),
+    )
+
+
+@fixture(scope="module")
+def graph(config: dict) -> ObjectGraph:
+    return create_object_graph(
+        "example",
+        testing=True,
+        loader=load_each(
+            load_from_dict(config),
+            load_from_environ,
+        ),
+    )
+
+
+@fixture(autouse=True, scope="module")
+def create_tables(graph: ObjectGraph) -> None:
+    Employee.__table__.drop(graph.postgres)
+    Employee.__table__.create(graph.postgres)
+
+
+@fixture
+def multi_tenant_encryptor(graph: ObjectGraph) -> MultiTenantEncryptor:
+    return graph.multi_tenant_encryptor
+
+
+@fixture
+def single_tenant_encryptor(
+    multi_tenant_encryptor: MultiTenantEncryptor,
+) -> SingleTenantEncryptor:
+    return multi_tenant_encryptor.encryptors[str(client_id)]
+
+
+@fixture
+def sessionmaker(graph: ObjectGraph) -> SessionMaker:
+    return graph.sessionmaker
+
+
+@fixture
+def session(sessionmaker: SessionMaker) -> Iterator[Session]:
+    session = sessionmaker()
+    try:
+        yield session
+        session.flush()  # Check that flush works
+    finally:
+        session.rollback()
+        session.close()
+
+
+def test_encrypt_and_search(
+    session: Session,
+    single_tenant_encryptor: SingleTenantEncryptor,
+    graph: ObjectGraph,
+) -> None:
+    with AwsKmsEncryptor.set_encryptor_context("test", single_tenant_encryptor):
+        session.add(employee := Employee(name="foo"))
+        assert employee.name_unencrypted is None
+        assert employee.name_encrypted is not None
+        assert employee.name_beacon is not None
+        assert employee.name == "foo"
+        session.commit()
+
+    # Now we test that we can search for the employee
+    # Note that this should use the defined beacon under the hood
+    with SessionContext(graph):
+        with AwsKmsEncryptor.set_encryptor_context("test", single_tenant_encryptor):
+            retrieved_employees = graph.employee_store_with_encryption.search_by_name("foo")
+            assert len(retrieved_employees) == 1
+            retrieved_employee = retrieved_employees[0]
+            # assert retrieved_employee.name == "foo"
+            assert retrieved_employee.id == employee.id
+
+
+

--- a/microcosm_postgres/tests/test_employee_store_with_encryption.py
+++ b/microcosm_postgres/tests/test_employee_store_with_encryption.py
@@ -146,7 +146,7 @@ def test_encrypt_and_search(
             retrieved_employees = graph.employee_store_with_encryption.search_by_name("foo")
             assert len(retrieved_employees) == 1
             retrieved_employee = retrieved_employees[0]
-            # assert retrieved_employee.name == "foo"
+            assert retrieved_employee.name == "foo"
             assert retrieved_employee.id == employee.id
 
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,10 @@ setup(
     ],
     extras_require={
         "metrics": "microcosm-metrics>=2.5.0",
-        "encryption": "aws-encryption-sdk>=2.0.0",
+        "encryption": [
+            "aws-encryption-sdk>=2.0.0",
+            "cryptography>=41",
+        ],
         "test": [
             "aws-encryption-sdk>=2.0.0",
             "coverage>=3.7.1",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 
 project = "microcosm-postgres"
-version = "3.5.5"
+version = "3.6.5"
 
 setup(
     name=project,

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 
 project = "microcosm-postgres"
-version = "3.6.5"
+version = "3.6.0"
 
 setup(
     name=project,


### PR DESCRIPTION
This PR gives us the ability to perform exact match searches on encrypted fields. It's done through the use of beacons.

Beacons are hash that's deterministically calculated such that every input has only one output.

More about beacons can be found on the aws encryption sdk docs: https://docs.aws.amazon.com/database-encryption-sdk/latest/devguide/using-beacons.html

Now we use the `*_beacon` value inside the SQL used in the query against the database e.g:
```
SELECT test_encryption_employee.id AS test_encryption_employee_id, test_encryption_employee.name_encrypted AS test_encryption_employee_name_encrypted, test_encryption_employee.name AS test_encryption_employee_name, test_encryption_employee.name_beacon AS test_encryption_employee_name_beacon
FROM test_encryption_employee
WHERE test_encryption_employee.name_beacon = %(name_beacon_1)s ORDER BY test_encryption_employee.id ASC
```

There is also support for `._in` queries using beacons e.g
```
select(Employee).filter(Employee.name.in_(["foo", "bar"]))
```
Under the hood we will beaconise each of the values and perform the search.