### PR TITLE
JSONEncoder - none as null

### DIFF
--- a/microcosm_postgres/encryption/v2/encoders.py
+++ b/microcosm_postgres/encryption/v2/encoders.py
@@ -82,7 +82,7 @@ class ArrayEncoder(Encoder[list[T]], Generic[T]):
 
 
 class JSONEncoder(Encoder[JSONType]):
-    sa_type = JSONB
+    sa_type = JSONB(none_as_null=True)
 
     def encode(self, value: JSONType) -> str:
         return json.dumps(value)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 
 project = "microcosm-postgres"
-version = "3.5.5"
+version = "3.5.6"
 
 setup(
     name=project,


### PR DESCRIPTION
Encryption v2 `JSONEncoder` to store null values as SQL NULL instead of JSON encoding of 'null'.