### PR TITLE
Custom, restricted KMS master key provider

### DIFF
--- a/microcosm_postgres/encryption/providers.py
+++ b/microcosm_postgres/encryption/providers.py
@@ -27,6 +27,14 @@ from microcosm.config.validation import typed
 
 
 class RestrictedKMSMasterKey(KMSMasterKey):
+    """
+    Customized KMS master key provider, to work with restriced KMS policy:
+
+        kms:GenerateDataKeyWithoutPlaintext
+        kms:Decrypt
+        kms:Encrypt
+
+    """
     def _generate_data_key(self, algorithm, encryption_context=None):
         kms_params = self._build_generate_data_key_request(algorithm, encryption_context)
         try:

--- a/microcosm_postgres/encryption/providers.py
+++ b/microcosm_postgres/encryption/providers.py
@@ -9,17 +9,56 @@ from aws_encryption_sdk import (
     DefaultCryptoMaterialsManager,
     LocalCryptoMaterialsCache,
 )
+from aws_encryption_sdk.exceptions import GenerateKeyError
 from aws_encryption_sdk.identifiers import EncryptionKeyType, WrappingAlgorithm
 from aws_encryption_sdk.internal.crypto.wrapping_keys import WrappingKey
 from aws_encryption_sdk.key_providers.kms import (
     DiscoveryAwsKmsMasterKeyProvider,
     DiscoveryFilter,
+    KMSMasterKey,
     StrictAwsKmsMasterKeyProvider,
 )
 from aws_encryption_sdk.key_providers.raw import RawMasterKeyProvider
+from aws_encryption_sdk.structures import DataKey, MasterKeyInfo
+from botocore.exceptions import ClientError
 from microcosm.api import defaults
 from microcosm.config.types import boolean
 from microcosm.config.validation import typed
+
+
+class RestrictedKMSMasterKey(KMSMasterKey):
+    def _generate_data_key(self, algorithm, encryption_context=None):
+        kms_params = self._build_generate_data_key_request(algorithm, encryption_context)
+        try:
+            response = self.config.client.generate_data_key_without_plaintext(**kms_params)
+            key_id = response["KeyId"]
+            ciphertext = response["CiphertextBlob"]
+        except (ClientError, KeyError):
+            raise GenerateKeyError(f"Master Key {self._key_id} unable to generate data key")
+
+        try:
+            response = self.config.client.decrypt(
+                CiphertextBlob=ciphertext,
+                EncryptionContext=encryption_context,
+                GrantTokens=self.config.grant_tokens,
+            )
+            plaintext = response["Plaintext"]
+        except (ClientError, KeyError):
+            raise GenerateKeyError(f"Master Key {key_id} unable to decrypt data key.")
+
+        return DataKey(
+            key_provider=MasterKeyInfo(
+                provider_id=self.provider_id,
+                key_info=key_id
+            ),
+            data_key=plaintext,
+            encrypted_data_key=ciphertext,
+        )
+
+
+class RestrictedStrictAwsKmsMasterKeyProvider(StrictAwsKmsMasterKeyProvider):
+
+    master_key_class = RestrictedKMSMasterKey
 
 
 class StaticMasterKeyProvider(RawMasterKeyProvider):
@@ -45,7 +84,7 @@ class StaticMasterKeyProvider(RawMasterKeyProvider):
         )
 
 
-def configure_encrypting_key_provider(graph, key_ids):
+def configure_encrypting_key_provider(graph, key_ids, restricted=False):
     """
     Configure a key provider.
 
@@ -59,6 +98,9 @@ def configure_encrypting_key_provider(graph, key_ids):
         return provider
 
     # use AWS provider
+    if restricted:
+        return RestrictedStrictAwsKmsMasterKeyProvider(key_ids=key_ids)
+
     return StrictAwsKmsMasterKeyProvider(key_ids=key_ids)
 
 

--- a/microcosm_postgres/tests/encryption/test_registry.py
+++ b/microcosm_postgres/tests/encryption/test_registry.py
@@ -22,6 +22,7 @@ def test_parse_config_simple():
             key_ids=["bar"],
             account_ids=["12345"],
             partitions=["aws"],
+            restricted_kms_policy=["false"],
         ),
         has_entries(
             foo=has_entries(
@@ -40,17 +41,20 @@ def test_parse_config_key_ids():
             key_ids=["bar;baz", "quuz;corge"],
             partitions=["aws", "aws-cn"],
             account_ids=["12345;67890", "23456;78901"],
+            restricted_kms_policy=["false", "true"],
         ),
         has_entries(
             foo=has_entries(
                 key_ids=["bar", "baz"],
                 partition="aws",
                 account_ids=["12345", "67890"],
+                restricted=False,
             ),
             quux=has_entries(
                 key_ids=["quuz", "corge"],
                 partition="aws-cn",
                 account_ids=["23456", "78901"],
+                restricted=True,
             ),
         ),
     )


### PR DESCRIPTION
Add a custom, restricted KMS master key provider, that could operate without `kms:GenerateDataKey` permission, but with `kms:GenerateDataKeyWithoutPlaintext` + `kms:Decode` instead. The provider is disabled by default, can be enabled by setting a flag per context key.