### PR TITLE
Misc improvements

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.7.1
+current_version = 3.7.2
 commit = False
 tag = False
 

--- a/microcosm_postgres/encryption/v2/column.py
+++ b/microcosm_postgres/encryption/v2/column.py
@@ -131,6 +131,9 @@ class encryption(hybrid_property[T], Generic[T]):
         self.encoder = encoder
         self.column_type = encoder.sa_type if column_type is NOT_SET else column_type
 
+        # This is used in the store auto filters
+        self.name = key
+
         beacon_field = f"{key}_beacon"
         encrypted_field = f"{key}_encrypted"
         unencrypted_field = f"{key}_unencrypted"

--- a/microcosm_postgres/encryption/v2/encoders.py
+++ b/microcosm_postgres/encryption/v2/encoders.py
@@ -4,7 +4,9 @@ from decimal import Decimal
 from enum import Enum
 from typing import (
     Any,
+    Callable,
     Generic,
+    ParamSpec,
     Protocol,
     TypeAlias,
     TypeVar,
@@ -23,6 +25,12 @@ JSONType: TypeAlias = (
 class Encoder(Protocol[T]):
     sa_type: Any
 
+    class EncodeException(Exception):
+        status_code = 400
+
+    class DecodeException(Exception):
+        status_code = 400
+
     def encode(self, value: T) -> str:
         ...
 
@@ -30,12 +38,44 @@ class Encoder(Protocol[T]):
         ...
 
 
+P = ParamSpec("P")
+R = TypeVar("R")
+
+# The original function takes any parameters and returns any type
+OriginalFunc = Callable[P, R]
+
+# The decorated function has the same signature as the original
+DecoratedFunc = Callable[P, R]
+
+
+def encode_exception_wrapper(func: OriginalFunc[P, R]) -> DecoratedFunc[P, R]:
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+        try:
+            return func(*args, **kwargs)
+        except Exception as e:
+            raise Encoder.EncodeException(f"Error encoding value: {e}")
+
+    return wrapper
+
+
+def decode_exception_wrapper(func: OriginalFunc[P, R]) -> DecoratedFunc[P, R]:
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+        try:
+            return func(*args, **kwargs)
+        except Exception as e:
+            raise Encoder.DecodeException(f"Error decoding value: {e}")
+
+    return wrapper
+
+
 class StringEncoder(Encoder[str]):
     sa_type = sqlalchemy.String
 
+    @encode_exception_wrapper
     def encode(self, value: str) -> str:
         return value
 
+    @decode_exception_wrapper
     def decode(self, value: str) -> str:
         return value
 
@@ -43,9 +83,11 @@ class StringEncoder(Encoder[str]):
 class IntEncoder(Encoder[int]):
     sa_type = sqlalchemy.Integer
 
+    @encode_exception_wrapper
     def encode(self, value: int) -> str:
         return str(value)
 
+    @decode_exception_wrapper
     def decode(self, value: str) -> int:
         return int(value)
 
@@ -53,9 +95,11 @@ class IntEncoder(Encoder[int]):
 class DecimalEncoder(Encoder[Decimal]):
     sa_type = sqlalchemy.Numeric(asdecimal=True)
 
+    @encode_exception_wrapper
     def encode(self, value: Decimal) -> str:
         return str(value)
 
+    @decode_exception_wrapper
     def decode(self, value: str) -> Decimal:
         return Decimal(value)
 
@@ -63,9 +107,11 @@ class DecimalEncoder(Encoder[Decimal]):
 class DatetimeEncoder(Encoder[datetime]):
     sa_type = sqlalchemy.DateTime(timezone=True)
 
+    @encode_exception_wrapper
     def encode(self, value: datetime) -> str:
         return value.isoformat()
 
+    @decode_exception_wrapper
     def decode(self, value: str) -> datetime:
         return datetime.fromisoformat(value)
 
@@ -75,9 +121,11 @@ class ArrayEncoder(Encoder[list[T]], Generic[T]):
         self.element_encoder = element_encoder
         self.sa_type = sqlalchemy.ARRAY(element_encoder.sa_type)
 
+    @encode_exception_wrapper
     def encode(self, value: list[T]) -> str:
         return json.dumps([self.element_encoder.encode(element) for element in value])
 
+    @decode_exception_wrapper
     def decode(self, value: str) -> list[T]:
         return [self.element_encoder.decode(v) for v in json.loads(value)]
 
@@ -85,9 +133,11 @@ class ArrayEncoder(Encoder[list[T]], Generic[T]):
 class JSONEncoder(Encoder[JSONType]):
     sa_type = JSONB(none_as_null=True)
 
+    @encode_exception_wrapper
     def encode(self, value: JSONType) -> str:
         return json.dumps(value)
 
+    @decode_exception_wrapper
     def decode(self, value: str) -> JSONType:
         return json.loads(value)
 
@@ -98,12 +148,14 @@ class Nullable(Encoder[T | None], Generic[T]):
         # Nullable encoder does not affect the sa_type
         self.sa_type = inner_encoder.sa_type
 
+    @encode_exception_wrapper
     def encode(self, value: T | None) -> str:
         if value is None:
             return json.dumps(value)
 
         return json.dumps(self.inner_encoder.encode(value))
 
+    @decode_exception_wrapper
     def decode(self, value: str) -> T | None:
         if (loaded_value := json.loads(value)) is None:
             return None
@@ -124,8 +176,10 @@ class EnumEncoder(Encoder[E], Generic[E]):
     def __init__(self, enum: type[E]):
         self._enum = enum
 
+    @encode_exception_wrapper
     def encode(self, value: E) -> str:
         return value.name
 
+    @decode_exception_wrapper
     def decode(self, value: str) -> E:
         return self._enum[value]

--- a/microcosm_postgres/encryption/v2/utils.py
+++ b/microcosm_postgres/encryption/v2/utils.py
@@ -1,0 +1,27 @@
+from typing import Any
+
+from microcosm_postgres.models import Model
+
+
+def members_override(
+    members_dict: dict[str, Any], encrypted_field_names: list[str]
+) -> dict[str, Any]:
+    """
+    We override the base _members method to ensure that we don't return
+    values for columns that don't exist in the database e.g *_unencrypted
+    """
+    base_dict = {
+        key: value
+        for key, value in members_dict.items()
+        # NB: ignore internal SQLAlchemy state and nested relationships
+        if not key.startswith("_") and not isinstance(value, Model)
+    }
+
+    for field in encrypted_field_names:
+        try:
+            base_dict[field] = base_dict[f"{field}_unencrypted"]
+            del base_dict[f"{field}_unencrypted"]
+        except KeyError:
+            pass
+
+    return base_dict

--- a/microcosm_postgres/tests/encryption/v2/test_encoders.py
+++ b/microcosm_postgres/tests/encryption/v2/test_encoders.py
@@ -5,6 +5,7 @@ from enum import Enum
 import pytest
 
 from microcosm_postgres.encryption.v2 import encoders
+from microcosm_postgres.encryption.v2.encoders import Encoder
 
 
 class AnEnum(Enum):
@@ -31,3 +32,42 @@ class AnEnum(Enum):
 )
 def test_encode_decode(encoder, value):
     assert encoder.decode(encoder.encode(value)) == value
+
+
+@pytest.mark.parametrize(
+    ("encoder", "value", "exception"),
+    [
+        # Decoding an invalid string to int
+        (encoders.IntEncoder(), "abc", Encoder.DecodeException),
+
+        # Decoding an invalid string to decimal
+        (encoders.DecimalEncoder(), "abc.xyz", Encoder.DecodeException),
+
+        # Decoding a non-list encoded string to array
+        (encoders.ArrayEncoder(encoders.StringEncoder()), "{foo,bar}", Encoder.DecodeException),
+
+        # Decoding a non-integer list encoded string
+        (encoders.ArrayEncoder(encoders.IntEncoder()), "[foo, bar]", Encoder.DecodeException),
+
+        # Decoding an invalid JSON string
+        (encoders.JSONEncoder(), "{'foo':'bar'}", Encoder.DecodeException),
+
+        # Decoding an invalid Nullable value
+        (encoders.Nullable(encoders.StringEncoder()), 123, Encoder.DecodeException),
+
+        # Decoding an invalid datetime string
+        (encoders.DatetimeEncoder(), "2021-25-09T25:63:75", Encoder.DecodeException),
+
+        # Decoding an invalid enum string
+        (encoders.EnumEncoder(AnEnum), "INVALID_ENUM", Encoder.DecodeException),
+
+        # Decoding an invalid nullable enum string
+        (encoders.Nullable(encoders.EnumEncoder(AnEnum)), "INVALID_ENUM", Encoder.DecodeException),
+    ],
+)
+def test_encode_decode_errors(encoder, value, exception):
+    with pytest.raises(exception):
+        if exception == Encoder.EncodeException:
+            encoder.encode(value)
+        else:
+            encoder.decode(value)

--- a/microcosm_postgres/tests/encryption/v2/test_utils.py
+++ b/microcosm_postgres/tests/encryption/v2/test_utils.py
@@ -1,0 +1,73 @@
+from typing import TYPE_CHECKING, ClassVar
+from uuid import uuid4
+
+from sqlalchemy import Table
+from sqlalchemy.orm import mapped_column
+from sqlalchemy_utils import UUIDType
+
+from microcosm_postgres.encryption.v2.column import encryption
+from microcosm_postgres.encryption.v2.encoders import IntEncoder, StringEncoder
+from microcosm_postgres.encryption.v2.encryptors import AwsKmsEncryptor
+from microcosm_postgres.encryption.v2.utils import members_override
+from microcosm_postgres.identifiers import new_object_id
+from microcosm_postgres.models import Model
+
+
+class Employee(Model):
+    __tablename__ = "test_encryption_employee_v2"
+    if TYPE_CHECKING:
+        __table__: ClassVar[Table]
+
+    id = mapped_column(UUIDType, primary_key=True, default=uuid4)
+
+    # Name requires beacon value for search
+    name = encryption("name", AwsKmsEncryptor(), StringEncoder())
+    name_encrypted = name.encrypted()
+    name_unencrypted = name.unencrypted(index=True)
+    name_beacon = name.beacon()
+
+    # Salary does not require beacon value
+    salary = encryption("salary", AwsKmsEncryptor(), IntEncoder())
+    salary_encrypted = salary.encrypted()
+    salary_unencrypted = salary.unencrypted()
+
+
+def test_members_override():
+    sample_dict = {
+        "_internal": "should not be in result",
+        "normal_field": "should remain unchanged",
+        "encrypted_field": "this should not be changed if no unencrypted counterpart exists",
+        "encrypted_field_unencrypted": "this should become 'encrypted_field'",
+        "relation": Employee(
+            id=new_object_id(),
+            name="should not be in result",
+            salary=100,
+        ),
+    }
+
+    result = members_override(sample_dict, ["encrypted_field"])
+
+    # Test case 1 & 2
+    assert "_internal" not in result
+    assert "relation" not in result
+
+    # Test case 3 & 4
+    assert "encrypted_field_unencrypted" not in result
+    assert result["encrypted_field"] == "this should become 'encrypted_field'"
+
+    # Test case 5
+    assert result["normal_field"] == "should remain unchanged"
+
+
+def test_members_override_missing_unencrypted():
+    sample_dict = {
+        "encrypted_field": "this should remain as it is if there's no unencrypted counterpart",
+    }
+
+    result = members_override(sample_dict, ["encrypted_field"])
+
+    assert (
+        result["encrypted_field"]
+        == "this should remain as it is if there's no unencrypted counterpart"
+    )
+    assert "encrypted_field_unencrypted" not in result

--- a/microcosm_postgres/tests/encryption/v2/test_utils.py
+++ b/microcosm_postgres/tests/encryption/v2/test_utils.py
@@ -14,7 +14,7 @@ from microcosm_postgres.models import Model
 
 
 class Employee(Model):
-    __tablename__ = "test_encryption_employee_v2"
+    __tablename__ = "test_encryption_employee_v3"
     if TYPE_CHECKING:
         __table__: ClassVar[Table]
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 
 project = "microcosm-postgres"
-version = "3.7.1"
+version = "3.7.2"
 
 setup(
     name=project,


### PR DESCRIPTION
* Adding util to help with overriding the `._members` method (useful for upserts where we iterate over the member attributes)
* Adding Encode/Decode exceptions
* Adding fix for auto filter fields (providing same interface as normal instrumented attributes)


From this:
```
def encode(self, value: list[T]) -> str:
>       return json.dumps([self.element_encoder.encode(element) for element in value])
E       TypeError: 'NoneType' object is not iterable
```

To this:
```
self = <microcosm_postgres.encryption.v2.encoders.ArrayEncoder object at 0x111830d60>, value = None

    def wrapped(self, value):
        try:
            return func(self, value)
        except Exception as e:
>           raise Encoder.EncodeException(f"Failed to encode value {value}") from e
E           microcosm_postgres.encryption.v2.encoders.Encoder.EncodeException: Failed to encode value None
```