### PR TITLE
feat: add a TextEncoder for encryption

### DIFF
--- a/microcosm_postgres/encryption/v2/encoders.py
+++ b/microcosm_postgres/encryption/v2/encoders.py
@@ -80,6 +80,18 @@ class StringEncoder(Encoder[Any]):
         return value
 
 
+class TextEncoder(Encoder[Any]):
+    sa_type = sqlalchemy.Text
+
+    @encode_exception_wrapper
+    def encode(self, value: Any) -> str:
+        return str(value)
+
+    @decode_exception_wrapper
+    def decode(self, value: str) -> Any:
+        return value
+
+
 class IntEncoder(Encoder[int]):
     sa_type = sqlalchemy.Integer
 

--- a/microcosm_postgres/tests/encryption/v2/test_encoders.py
+++ b/microcosm_postgres/tests/encryption/v2/test_encoders.py
@@ -17,6 +17,7 @@ class AnEnum(Enum):
     ("encoder", "value"),
     [
         (encoders.StringEncoder(), "foo"),
+        (encoders.TextEncoder(), "The quick brown fox jumps over the lazy dog"),
         (encoders.IntEncoder(), 1),
         (encoders.DecimalEncoder(), Decimal(1.0)),
         (encoders.ArrayEncoder(encoders.StringEncoder()), ["foo", "bar"]),
@@ -48,6 +49,19 @@ def test_string_encoder(input, output):
 
 
 @pytest.mark.parametrize(
+    ("input", "output"),
+    [
+        ("foo", "foo"),
+        (1, "1"),
+        (Decimal(1.0), "1"),
+        (True, "True"),
+    ],
+)
+def test_text_encoder(input, output):
+    assert encoders.TextEncoder().encode(input) == output
+
+
+@pytest.mark.parametrize(
     ("encoder", "value", "exception"),
     [
         # Decoding an invalid string to int
@@ -67,6 +81,7 @@ def test_string_encoder(input, output):
 
         # Decoding an invalid Nullable value
         (encoders.Nullable(encoders.StringEncoder()), 123, Encoder.DecodeException),
+        (encoders.Nullable(encoders.TextEncoder()), 123, Encoder.DecodeException),
 
         # Decoding an invalid datetime string
         (encoders.DatetimeEncoder(), "2021-25-09T25:63:75", Encoder.DecodeException),

--- a/microcosm_postgres/tests/encryption/v2/test_encryption.py
+++ b/microcosm_postgres/tests/encryption/v2/test_encryption.py
@@ -25,6 +25,7 @@ from microcosm_postgres.encryption.v2.encoders import (
     JSONEncoder,
     Nullable,
     StringEncoder,
+    TextEncoder,
 )
 from microcosm_postgres.encryption.v2.encryptors import AwsKmsEncryptor
 from microcosm_postgres.models import Model
@@ -55,6 +56,15 @@ class Employee(Model):
     )
     description_encrypted = description.encrypted()
     description_unencrypted = description.unencrypted()
+
+    notes = encryption(
+        "notes",
+        AwsKmsEncryptor(),
+        Nullable(TextEncoder()),
+        default=None,
+    )
+    notes_encrypted = notes.encrypted()
+    notes_unencrypted = notes.unencrypted()
 
     roles = encryption(
         "roles",
@@ -170,12 +180,16 @@ def test_encrypt_with_client(
             name="foo",
             extras={"foo": "bar"},
             type=EmployeeType.FULL_TIME,
+            notes="baz"
         ))
         assert employee.name_unencrypted is None
         assert employee.name_encrypted is not None
         assert employee.name == "foo"
         assert employee.extras == {"foo": "bar"}
         assert employee.type == EmployeeType.FULL_TIME
+        assert employee.notes_unencrypted is None
+        assert employee.notes_encrypted is not None
+        assert employee.notes == "baz"
 
 
 def test_encrypt_with_client_default(


### PR DESCRIPTION
This PR adds a `TextEncoder` for encryption. It acts like the existing `StringEncoder`, but for the `sqlalchemy.Text` type.