### PR TITLE
Fixing bug with empty array - array encoder - encryption v2

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.8.1
+current_version = 3.8.2
 commit = False
 tag = False
 

--- a/microcosm_postgres/encryption/v2/encoders.py
+++ b/microcosm_postgres/encryption/v2/encoders.py
@@ -148,7 +148,6 @@ class ArrayEncoder(Encoder[list[T]], Generic[T]):
         raw = [self.element_encoder.encode(element) for element in value]
         if keep_as_array:
             assert isinstance(raw, list)
-            assert isinstance(raw[0], str)
             return raw  # type: ignore[return-value]
         else:
             return json.dumps(raw)

--- a/microcosm_postgres/encryption/v2/encryptors.py
+++ b/microcosm_postgres/encryption/v2/encryptors.py
@@ -172,7 +172,7 @@ class AwsKmsEncryptor(Encryptor):
             assert isinstance(value, str)
             _beacon = encryptor.beacon(value)  # type: ignore[assignment]
 
-        if _beacon is None or (use_array and len(_beacon) == 0):
+        if _beacon is None:
             raise self.BeaconKeyNotSet()
 
         return _beacon  # type: ignore[return-value]

--- a/microcosm_postgres/tests/test_employee_store_with_encryption.py
+++ b/microcosm_postgres/tests/test_employee_store_with_encryption.py
@@ -820,3 +820,27 @@ def test_upsert_existing_employee_with_encryption(
         assert employees[0].name_beacon == "b7ba82ea80985bd15f7e9909c6ff831c6c019d916bc0aff43646584c7901f7a5"
         assert employees[0].salary == 1300
         assert employees[0].age == 40
+
+
+def test_create_employee_with_empty_array_of_skills(
+    graph: ObjectGraph,
+    single_tenant_encryptor: SingleTenantEncryptor,
+) -> None:
+    """
+    Test that an employee with an empty array of skills can be created.
+
+    """
+
+    with (
+        SessionContext(graph) as context,
+        transaction(),
+        AwsKmsEncryptor.set_encryptor_context("test", single_tenant_encryptor)
+    ):
+        context.recreate_all()
+        session = context.session
+
+        employee = Employee(
+            name="Brian",
+            skills=[],
+        )
+        session.add(employee)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 
 project = "microcosm-postgres"
-version = "3.8.1"
+version = "3.8.2"
 
 setup(
     name=project,


### PR DESCRIPTION
The implementation that was put together for beacons has a small bug which prevents empty arrays from being used:
```
microcosm_postgres.encryption.v2.encoders.Encoder.EncodeException: Error encoding value: Error encoding value: list index out of range
```

which is due to the `isinstance` check:
```
assert isinstance(raw[0], str)
```
