### PR TITLE
Default encryptor not created if no account ids / key ids

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.9.0
+current_version = 3.9.1
 commit = False
 tag = False
 

--- a/microcosm_postgres/encryption/encryptor.py
+++ b/microcosm_postgres/encryption/encryptor.py
@@ -107,11 +107,14 @@ class MultiTenantEncryptor:
     def __contains__(self, encryption_context_key: str) -> bool:
         return encryption_context_key in self.encryptors or self.default_key in self.encryptors
 
-    def __getitem__(self, encryption_context_key: str) -> SingleTenantEncryptor:
+    def __getitem__(self, encryption_context_key: str) -> SingleTenantEncryptor | None:
         try:
             return self.encryptors[encryption_context_key]
         except KeyError:
-            return self.encryptors[self.default_key]
+            try:
+                return self.encryptors[self.default_key]
+            except KeyError:
+                return None
 
     def encrypt(self, encryption_context_key: str, plaintext: str) -> Tuple[bytes, Sequence[str]] | None:
         encryptor = self[encryption_context_key]

--- a/microcosm_postgres/encryption/encryptor.py
+++ b/microcosm_postgres/encryption/encryptor.py
@@ -118,14 +118,20 @@ class MultiTenantEncryptor:
 
     def encrypt(self, encryption_context_key: str, plaintext: str) -> Tuple[bytes, Sequence[str]] | None:
         encryptor = self[encryption_context_key]
+        if encryptor is None:
+            return None
         return encryptor.encrypt(encryption_context_key, plaintext)
 
-    def decrypt(self, encryption_context_key: str, ciphertext: bytes) -> str:
+    def decrypt(self, encryption_context_key: str, ciphertext: bytes) -> str | None:
         encryptor = self[encryption_context_key]
+        if encryptor is None:
+            return None
         return encryptor.decrypt(encryption_context_key, ciphertext)
 
     def beacon(self, encryption_context_key: str, value: str) -> str | None:
         encryptor = self[encryption_context_key]
+        if encryptor is None:
+            return None
         return encryptor.beacon(value)
 
 

--- a/microcosm_postgres/encryption/registry.py
+++ b/microcosm_postgres/encryption/registry.py
@@ -111,22 +111,25 @@ class MultiTenantKeyRegistry:
             for context_key, context_data in self.keys.items()
         }
 
-        # Then we need to add the default encryptor
-        encryptors[ENCRYPTION_V2_DEFAULT_KEY] = SingleTenantEncryptor(
-            encrypting_materials_manager=None,
-            decrypting_materials_manager=configure_materials_manager(
-                graph,
-                key_provider=configure_decrypting_key_provider(
+        if len(self.all_account_ids) > 0 and len(self.all_key_ids) > 0:
+            # We'll only create a default encryptor if we have at least one
+            # account_id and key_id
+
+            encryptors[ENCRYPTION_V2_DEFAULT_KEY] = SingleTenantEncryptor(
+                encrypting_materials_manager=None,
+                decrypting_materials_manager=configure_materials_manager(
                     graph,
-                    self.all_account_ids,  # Use all accumulated account_ids
-                    "aws",  # Assuming the partition is always "aws"
-                    self.all_key_ids,  # Use all accumulated key_ids
+                    key_provider=configure_decrypting_key_provider(
+                        graph,
+                        self.all_account_ids,  # Use all accumulated account_ids
+                        "aws",  # Assuming the partition is always "aws"
+                        self.all_key_ids,  # Use all accumulated key_ids
+                    ),
                 ),
-            ),
-            # TODO - need to work on being able to use multiple beacons
-            # from different accounts
-            beacon_key="test-key",
-        )
+                # TODO - need to work on being able to use multiple beacons
+                # from different accounts
+                beacon_key="test-key",
+            )
 
         return MultiTenantEncryptor(
             encryptors=encryptors,

--- a/microcosm_postgres/encryption/v2/encryptors.py
+++ b/microcosm_postgres/encryption/v2/encryptors.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from contextvars import ContextVar
 from typing import (
     Any,
@@ -117,7 +117,10 @@ class AwsKmsEncryptor(Encryptor):
         client_id = normalise(graph.request_context()).get(X_REQUEST_CLIENT_HEADER)
         if client_id is None or client_id not in encryptors.encryptors:
             # Then we return back the default encryptor
-            return cls.set_encryptor_context(ENCRYPTION_V2_DEFAULT_KEY, encryptors[ENCRYPTION_V2_DEFAULT_KEY])
+            default_encryptor = encryptors[ENCRYPTION_V2_DEFAULT_KEY]
+            if default_encryptor is None:
+                return nullcontext()
+            return cls.set_encryptor_context(ENCRYPTION_V2_DEFAULT_KEY, default_encryptor)
         return cls.set_encryptor_context(client_id, encryptors[client_id])
 
     @classmethod

--- a/microcosm_postgres/encryption/v2/encryptors.py
+++ b/microcosm_postgres/encryption/v2/encryptors.py
@@ -121,7 +121,11 @@ class AwsKmsEncryptor(Encryptor):
             if default_encryptor is None:
                 return nullcontext()
             return cls.set_encryptor_context(ENCRYPTION_V2_DEFAULT_KEY, default_encryptor)
-        return cls.set_encryptor_context(client_id, encryptors[client_id])
+
+        client_encryptor = encryptors[client_id]
+        if client_encryptor is None:
+            return nullcontext()
+        return cls.set_encryptor_context(client_id, client_encryptor)
 
     @classmethod
     def register_flask_context(cls, graph: ObjectGraph) -> None:

--- a/microcosm_postgres/tests/encryption/test_registry.py
+++ b/microcosm_postgres/tests/encryption/test_registry.py
@@ -5,6 +5,8 @@ Test registry configuration.
 from unittest import SkipTest
 
 from hamcrest import assert_that, has_entries
+from microcosm.loaders import load_from_dict
+from microcosm.object_graph import create_object_graph
 
 from microcosm_postgres.encryption.registry import parse_config
 
@@ -58,3 +60,24 @@ def test_parse_config_key_ids():
             ),
         ),
     )
+
+
+def test_default_encryptor_not_created_when_no_config_available():
+    """
+    Tests that when we have no config then we don't try to make
+    a default encryptor as it can cause errors in the application.
+
+    """
+    loader = load_from_dict(
+        multi_tenant_key_registry=dict(),
+    )
+
+    graph = create_object_graph(
+        "example",
+        testing=True,
+        loader=loader,
+        import_name="microcosm_postgres",
+    )
+
+    multi_tenant_encryptor = graph.multi_tenant_key_registry.make_encryptor(graph)
+    assert len(multi_tenant_encryptor.encryptors) == 0

--- a/microcosm_postgres/tests/test_employee_store_with_encryption.py
+++ b/microcosm_postgres/tests/test_employee_store_with_encryption.py
@@ -193,10 +193,6 @@ def config() -> dict:
                 "beacon_key",
             ],
         ),
-
-        postgres=dict(
-            echo=True,
-        )
     )
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 
 project = "microcosm-postgres"
-version = "3.9.0"
+version = "3.9.1"
 
 setup(
     name=project,


### PR DESCRIPTION
updating default encryption creation such that it's only created if there are available account ids / key ids in config.