### PR TITLE
Fix default decryptor with column defaults

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.9.1
+current_version = 3.9.2
 commit = False
 tag = False
 

--- a/microcosm_postgres/encryption/v2/encryptors.py
+++ b/microcosm_postgres/encryption/v2/encryptors.py
@@ -141,7 +141,11 @@ class AwsKmsEncryptor(Encryptor):
             return response
 
     def should_encrypt(self) -> bool:
-        return self.encryptor_context is not None
+        if self.encryptor_context is None:
+            return False
+
+        _, encryptor = self.encryptor_context
+        return encryptor.encrypting_materials_manager is not None
 
     def encrypt(self, value: str) -> bytes | None:
         if not self.should_encrypt():

--- a/microcosm_postgres/tests/encryption/v2/test_encryption.py
+++ b/microcosm_postgres/tests/encryption/v2/test_encryption.py
@@ -374,7 +374,7 @@ def test_encrypt_with_default_encryptor(
         assert employee.name_encrypted is None
         assert employee.name == "foo2"
         assert employee.bio_unencrypted == ""  # the default
-        assert employee.bio_encrypted == None
+        assert employee.bio_encrypted is None
 
     # Then we test we can read back the data with no encryptor set
     with (

--- a/microcosm_postgres/tests/encryption/v2/test_encryption.py
+++ b/microcosm_postgres/tests/encryption/v2/test_encryption.py
@@ -88,11 +88,22 @@ class Employee(Model):
     extras_encrypted = extras.encrypted()
     extras_unencrypted = extras.unencrypted()
 
+    bio = encryption("bio", AwsKmsEncryptor(), StringEncoder(), default="")
+    bio_encrypted = bio.encrypted()
+    bio_unencrypted = bio.unencrypted()
+
     __table_args__ = (
         # NB check constraint to enforce null values in JSON columns
         CheckConstraint(
             name="employee_extras_or_encrypted_is_null",
             sqltext="extras IS NULL OR extras_encrypted IS NULL",
+        ),
+        CheckConstraint(
+            name="employee_bio_is_not_null",
+            sqltext=(
+                "(bio IS NULL OR bio_encrypted IS NULL) AND "
+                "(bio IS NOT NULL OR bio_encrypted IS NOT NULL)"
+            ),
         ),
     )
 
@@ -358,10 +369,12 @@ def test_encrypt_with_default_encryptor(
             extras={"foo2": "bar"},
             notes="baz"
         ))
+        session.commit()
         assert employee.name_unencrypted == "foo2"
         assert employee.name_encrypted is None
         assert employee.name == "foo2"
-        session.commit()
+        assert employee.bio_unencrypted == ""  # the default
+        assert employee.bio_encrypted == None
 
     # Then we test we can read back the data with no encryptor set
     with (

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 
 project = "microcosm-postgres"
-version = "3.9.1"
+version = "3.9.2"
 
 setup(
     name=project,


### PR DESCRIPTION
Fixing default decryptor to not interfere with column defaults; the encryptor should claim in _should encrypt_ only in case when the encryptor exists with non-null encrypting materials manager.