### PR TITLE
Adding beacon hashing algorithm

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.10.0
+current_version = 3.11.0
 commit = False
 tag = False
 

--- a/microcosm_postgres/encryption/encryptor.py
+++ b/microcosm_postgres/encryption/encryptor.py
@@ -11,9 +11,11 @@ from typing import (
 
 from aws_encryption_sdk import CommitmentPolicy, EncryptionSDKClient
 from aws_encryption_sdk.materials_managers.base import CryptoMaterialsManager
+from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, hmac
 
 from microcosm_postgres.encryption.constants import ENCRYPTION_V1_DEFAULT_KEY
+from microcosm_postgres.encryption.v2.beacons import BeaconHashAlgorithm
 
 
 class SingleTenantEncryptor:
@@ -75,13 +77,24 @@ class SingleTenantEncryptor:
         )
         return plaintext.decode("utf-8")
 
-    def beacon(self, value: str) -> str | None:
-        if self._beacon_key is None:
-            return None
+    def beacon(self, value: str, algorithm: BeaconHashAlgorithm | None = None) -> str | None:
+        if algorithm in [BeaconHashAlgorithm.SHA_256, None]:
+            # Note that this is the default behaviour
+            # Create a SHA-256 hash object
+            digest = hashes.Hash(hashes.SHA256(), backend=default_backend())
+            digest.update(value.encode("utf-8"))
+            return digest.finalize().hex()
 
-        h = hmac.HMAC(self._beacon_key, hashes.SHA256())
-        h.update(value.encode("utf-8"))
-        return h.finalize().hex()
+        elif algorithm == BeaconHashAlgorithm.HMAC_SHA_256:
+            if self._beacon_key is None:
+                return None
+
+            h = hmac.HMAC(self._beacon_key, hashes.SHA256())
+            h.update(value.encode("utf-8"))
+            return h.finalize().hex()
+
+        else:
+            return None
 
     def unpack_key_id(self, key_provider):
         key_info = key_provider.key_info
@@ -128,11 +141,16 @@ class MultiTenantEncryptor:
             return None
         return encryptor.decrypt(encryption_context_key, ciphertext)
 
-    def beacon(self, encryption_context_key: str, value: str) -> str | None:
+    def beacon(
+        self,
+        encryption_context_key: str,
+        value: str,
+        algorithm: BeaconHashAlgorithm | None = None
+    ) -> str | None:
         encryptor = self[encryption_context_key]
         if encryptor is None:
             return None
-        return encryptor.beacon(value)
+        return encryptor.beacon(value, algorithm=algorithm)
 
 
 Encryptor = Union[

--- a/microcosm_postgres/encryption/v2/beacons.py
+++ b/microcosm_postgres/encryption/v2/beacons.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class BeaconHashAlgorithm(Enum):
+    SHA_256 = "SHA-256"
+    HMAC_SHA_256 = "HMAC+SHA-256"

--- a/microcosm_postgres/tests/encryption/v2/reencryption/test_cli.py
+++ b/microcosm_postgres/tests/encryption/v2/reencryption/test_cli.py
@@ -24,6 +24,7 @@ from sqlalchemy.orm import (
 
 from microcosm_postgres.context import SessionContext, transaction
 from microcosm_postgres.encryption.encryptor import MultiTenantEncryptor, SingleTenantEncryptor
+from microcosm_postgres.encryption.v2.beacons import BeaconHashAlgorithm
 from microcosm_postgres.encryption.v2.column import encryption
 from microcosm_postgres.encryption.v2.encoders import StringEncoder
 from microcosm_postgres.encryption.v2.encryptors import AwsKmsEncryptor
@@ -42,7 +43,7 @@ class Employee(NewModel):
     id = mapped_column(UUID, primary_key=True, default=uuid4)
 
     # Name requires beacon value for search
-    name = encryption("name", AwsKmsEncryptor(), StringEncoder())
+    name = encryption("name", AwsKmsEncryptor(), StringEncoder(), beacon_algorithm=BeaconHashAlgorithm.HMAC_SHA_256)
     name_encrypted = name.encrypted()
     name_unencrypted = name.unencrypted(index=True)
     name_beacon = name.beacon()

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 
 project = "microcosm-postgres"
-version = "3.10.0"
+version = "3.11.0"
 
 setup(
     name=project,


### PR DESCRIPTION
Adding ability to specify which hashing algorithm you'd like to use for the beacon generation.

This can be configured at the column level. 

Default is to use the plain SHA-256.